### PR TITLE
Auto-focus browser URL bar and improve URL normalization

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -225,7 +225,7 @@ initFileExplorer({ openFileEditor, openDiffTab, refreshChanges, startTask, refre
 initGitChanges({ refreshFileTree, startTask, loadProjects, switchTab, addTabToOrder, renderTabBar, tabsForWorkDir });
 initPostCommitPromptBridge();
 initGitHubViewBridge({ refreshGitHub, switchRightPanelTab });
-initJourneyZone({ doPush, doPullLatestMain, openBranchModal, refreshChanges, switchToGitHubView, showChangesStatus, startTask, refreshWorktreeMetrics, loadProjects, openWorkDir });
+initJourneyZone({ doPush, doPullLatestMain, openBranchModal, refreshChanges, showChangesStatus, startTask, refreshWorktreeMetrics, loadProjects, openWorkDir });
 initGitHubPanel({ startTask, switchRightPanelTab });
 initGitHubPRs({ loadProjects, openWorkDir, closeTab, tabsForWorkDir });
 initTodoPanel({ loadProjects, openWorkDir, startTask, showGitHubIssueDetail, switchRightPanelTab, switchToGitHubView });

--- a/renderer/journey-zone.js
+++ b/renderer/journey-zone.js
@@ -12,7 +12,6 @@ let _doPush = null;
 let _doPullLatestMain = null;
 let _openBranchModal = null;
 let _refreshChanges = null;
-let _switchToGitHubView = null;
 let _showChangesStatus = null;
 let _startTask = null;
 let _refreshWorktreeMetrics = null;
@@ -24,7 +23,6 @@ export function initJourneyZone(deps) {
   _doPullLatestMain = deps.doPullLatestMain;
   _openBranchModal = deps.openBranchModal;
   _refreshChanges = deps.refreshChanges;
-  _switchToGitHubView = deps.switchToGitHubView;
   _showChangesStatus = deps.showChangesStatus;
   _startTask = deps.startTask;
   _refreshWorktreeMetrics = deps.refreshWorktreeMetrics;
@@ -150,6 +148,17 @@ const REVIEW_LOOP_PROMPT = `Run an automated review loop on unstaged git changes
 4. Loop back to step 1. Repeat until all files pass and are staged, or 5 cycles complete.
 5. When git diff returns empty, report summary. Skip files that fail 3 times. Run git diff --stat before each cycle.`;
 
+const PUBLISH_PR_PROMPT = `Push this branch to origin and open a pull request.
+
+1. Inspect the branch: run \`git status\`, \`git log --oneline main..HEAD\` (or the appropriate base), and \`git diff main...HEAD --stat\` so you understand what has changed and why.
+2. Push the current branch to origin. If it has no upstream yet, use \`git push -u origin HEAD\`.
+3. Create the PR with \`gh pr create --base main\`, passing \`--title\` and \`--body\`. Craft them carefully:
+   - Title: concise, imperative, under 70 characters, summarizing the overall change.
+   - Body: a short "## Summary" (2–4 bullets on WHAT changed) followed by a "## Why" section (the motivation — the problem being solved or the behavior being improved). If relevant, add a "## Notes" section for caveats, follow-ups, or anything a reviewer should know. Pass the body via a heredoc so newlines and markdown are preserved.
+4. When the PR is created, print the PR URL so the user can open it.
+
+Do not amend commits, force-push, or change branch history — just push what is there and open the PR.`;
+
 async function _handleJourneyAction(action, btn) {
   const workDir = tabState.activeWorkDir;
   if (!workDir) return;
@@ -189,34 +198,7 @@ async function _handleJourneyAction(action, btn) {
     finally { btn.disabled = false; btn.textContent = 'Push'; }
 
   } else if (action === 'push-pr' || action === 'publish-pr') {
-    const origLabel = btn.textContent;
-    btn.disabled = true;
-    btn.textContent = 'Creating PR...';
-    try {
-      const pushResult = await _doPush?.(workDir, { autoUpstream: true });
-      if (!pushResult?.ok) {
-        _showChangesStatus?.(pushResult?.error || 'Push failed', 'error');
-        return;
-      }
-      const branch = await window.gitDiff.currentBranch(workDir);
-      if (!branch) {
-        _showChangesStatus?.('Could not determine branch name', 'error');
-        return;
-      }
-      let title = branch.split('/').pop().replace(/[-_]/g, ' ').replace(/^\w/, c => c.toUpperCase());
-      let body = '';
-      btn.textContent = 'Generating PR message...';
-      const gen = await window.gitOps.generatePRMsg(workDir);
-      if (gen.ok) { title = gen.title; body = gen.body; }
-      btn.textContent = 'Creating PR...';
-      const prResult = await window.github.prCreate(workDir, title, body, 'main', false);
-      if (prResult.ok) {
-        _showChangesStatus?.('PR created', 'success');
-        _switchToGitHubView?.(true, { section: 'prs' });
-      } else {
-        _showChangesStatus?.(prResult.error || 'PR creation failed', 'error');
-      }
-    } finally { btn.disabled = false; btn.textContent = origLabel; }
+    _startTask?.('github-specialist', workDir, { initialPrompt: PUBLISH_PR_PROMPT });
 
   } else if (action === 'merge-to-main') {
     btn.disabled = true;

--- a/renderer/tabs.js
+++ b/renderer/tabs.js
@@ -230,7 +230,12 @@ export function switchTab(id) {
       height: Math.round(rect.height),
     } : null;
     window.browserView.setActive(id, bounds);
-    window.browserView.focus(id);
+    if (tab.navInput && !tab.navInput.value) {
+      tab.navInput.focus();
+      tab.navInput.select();
+    } else {
+      window.browserView.focus(id);
+    }
   } else {
     window.browserView.setActive(null);
     if (tab.type === 'editor') {

--- a/renderer/terminals.js
+++ b/renderer/terminals.js
@@ -219,6 +219,21 @@ function setupBrowserViewVisibility() {
 
 // ── Browser tab creation ───────────────────────────────────────
 
+// Local/loopback/private addresses default to http; public hosts to https.
+function normalizeUrl(input) {
+  if (/^https?:\/\//i.test(input)) return input;
+  const host = input.split('/')[0].split(':')[0].toLowerCase();
+  const isLocal =
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(host) ||
+    host === '::1';
+  return (isLocal ? 'http://' : 'https://') + input;
+}
+
 export async function startBrowser(workDir) {
   const workDirChanged = tabState.activeWorkDir !== workDir;
   tabState.activeWorkDir = workDir;
@@ -290,10 +305,9 @@ export async function startBrowser(workDir) {
 
   navInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') {
-      let val = navInput.value.trim();
+      const val = navInput.value.trim();
       if (!val) return;
-      if (!val.match(/^https?:\/\//)) val = 'https://' + val;
-      window.browserView.navigate(id, val);
+      window.browserView.navigate(id, normalizeUrl(val));
     }
   });
 


### PR DESCRIPTION
Improve the browser tab experience by auto-focusing the navigation input when switching to an empty browser tab, so users can start typing a URL immediately. Also refactor URL normalization to pick the right scheme based on the host — local and private addresses default to `http://`, while public hosts get `https://`.

- Auto-focus and select the URL bar text when switching to a browser tab with no URL loaded
- Distinguish local/private hosts (localhost, 127.0.0.1, RFC1918 ranges, `.local`) from public hosts during URL normalization
- Default local/private addresses to `http://` and public hosts to `https://` when the user omits a scheme