### PR TITLE
Make terminal URLs clickable with web-links addon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@electron/rebuild": "^4.0.3",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "electron": "^41.1.0",
         "node-pty": "^1.1.0"
@@ -343,6 +344,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@electron/rebuild": "^4.0.3",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "electron": "^41.1.0",
     "node-pty": "^1.1.0"

--- a/renderer/terminals.js
+++ b/renderer/terminals.js
@@ -39,9 +39,10 @@ export async function startTask(agentName, workDir, options = {}) {
   terminalContainers.appendChild(pane);
 
   // Load xterm via ESM dynamic import
-  const [{ Terminal }, { FitAddon }] = await Promise.all([
+  const [{ Terminal }, { FitAddon }, { WebLinksAddon }] = await Promise.all([
     import('../node_modules/@xterm/xterm/lib/xterm.mjs'),
     import('../node_modules/@xterm/addon-fit/lib/addon-fit.mjs'),
+    import('../node_modules/@xterm/addon-web-links/lib/addon-web-links.mjs'),
   ]);
 
   const term = new Terminal({
@@ -52,6 +53,10 @@ export async function startTask(agentName, workDir, options = {}) {
   });
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
+  term.loadAddon(new WebLinksAddon((event, url) => {
+    if (event.metaKey) window.windowActions.openExternal(url);
+    else startBrowser(workDir, url);
+  }));
   term.open(pane);
 
   // Spawn pty — returns tab id
@@ -234,7 +239,7 @@ function normalizeUrl(input) {
   return (isLocal ? 'http://' : 'https://') + input;
 }
 
-export async function startBrowser(workDir) {
+export async function startBrowser(workDir, initialUrl = null) {
   const workDirChanged = tabState.activeWorkDir !== workDir;
   tabState.activeWorkDir = workDir;
   if (workDirChanged) refreshRightPanel(workDir);
@@ -272,11 +277,12 @@ export async function startBrowser(workDir) {
   pane.appendChild(viewport);
 
   const navInput = nav.querySelector('.browser-url');
-  navInput.value = '';
+  navInput.value = initialUrl || '';
 
   // Create WebContentsView in main process
   try {
     await window.browserView.create(id);
+    if (initialUrl) window.browserView.navigate(id, initialUrl);
   } catch (err) {
     pane.remove();
     const hasTabs = [...tabState.tabs.values()].some(t => t.workDir === workDir);

--- a/styles.css
+++ b/styles.css
@@ -1089,6 +1089,16 @@
       flex-shrink: 0;
       user-select: none;
     }
+    .term-tab:has(.term-tab-label) {
+      width: 180px;
+      box-sizing: border-box;
+    }
+    .term-tab-label {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
     .term-tab:hover {
       background: #252525;
       color: #ccc;


### PR DESCRIPTION
## Summary
- Add `@xterm/addon-web-links` dependency and load it into each terminal on startup.
- Clicking a URL opens it in an in-app browser tab; meta+click opens it in the system browser.
- Extend `startBrowser(workDir, initialUrl)` so a click can open a new browser tab already pointed at the URL.
- Tighten `.term-tab` sizing with a fixed 180px width and ellipsis-truncated labels.

## Why
Terminal output frequently contains URLs (docs, dashboards, PR links, error traces). Previously they were inert text, so users had to copy-paste into a browser. Making them clickable — with meta+click as the familiar "open in system browser" escape hatch — matches the behavior users expect from modern terminals and keeps the in-app browser useful as the default destination. The tab-label overflow fix keeps tab bars tidy once labels can grow (e.g. URL-bearing browser tabs).

## Notes
- The addon is loaded via the same `node_modules/...` ESM dynamic-import pattern already used for `xterm` and `addon-fit`; no bundler or new build step.
- `startBrowser` remains backward-compatible — `initialUrl` defaults to `null`.