### PR TITLE
Clear browser view when leaving browser tab contexts

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -110,6 +110,7 @@ export function openWorkDir(workDir) {
     tabState.activeWorkDir = workDir;
     tabState.activeTabId = null;
     refreshRightPanel(workDir);
+    window.browserView.setActive(null);
     mainPanel.style.display = 'none';
     settingsPanel.classList.remove('active');
     terminalView.classList.remove('active');
@@ -155,6 +156,7 @@ function openProjectScope(projectPath, section) {
   }
 
   // Show launchpad with project-scope message; hide terminal
+  window.browserView.setActive(null);
   mainPanel.style.display = 'none';
   settingsPanel.classList.remove('active');
   terminalView.classList.remove('active');

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -48,6 +48,7 @@ export function enterSettings() {
   savedActiveTabId = tabState.activeTabId;
   savedActiveWorkDir = tabState.activeWorkDir;
   tabState.activeTabId = null;
+  window.browserView.setActive(null);
   sidebarHeader.style.display = 'none';
   projectList.style.display = 'none';
   sidebarFooter.style.display = 'none';


### PR DESCRIPTION
## Summary
- Call `window.browserView.setActive(null)` when opening a worktree (`renderer/app.js:113`), entering project scope (`renderer/app.js:159`), and entering settings (`renderer/settings.js:51`).

## Why
The browser tab uses a native `WebContentsView` overlaid on top of the renderer. Because it lives above the DOM, hiding renderer panels doesn't hide it — so switching away from a browser tab (e.g. to a worktree, project scope, or settings) left the browser content floating over whatever view the user navigated to. Detaching the active browser view on these transitions makes the context switch visually consistent.

## Notes
- No changes to main-process browser-view logic; this only ensures the renderer signals "no active browser" when the UI context no longer has a browser tab in focus.