### PR TITLE
Add GitHub clone flow for creating projects from repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ renderer/
   file-explorer.js          — File tree rendering, panel switching, resize
   file-explorer-ops.js      — Rename, create, context menu, keyboard nav
   worktree-modals.js        — Worktree create/delete/merge modals
+  clone-modal.js            — "Clone from GitHub" modal (URL / My repos tabs, destination picker)
   git-changes.js            — Status panel, staging, sub-nav, GitHub view mode (incremental DOM)
   git-changes-graph.js      — Git graph computation, commit/stash element rendering
   git-changes-status.js     — Status toast for changes panel

--- a/index.html
+++ b/index.html
@@ -246,6 +246,50 @@
     </div>
   </div>
 
+  <!-- Add-project popover (opens from sidebar + button) -->
+  <div id="add-project-menu">
+    <button class="add-project-menu-item" data-action="open-folder">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+      Open existing folder…
+    </button>
+    <button class="add-project-menu-item" data-action="clone-github">
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+      Clone from GitHub…
+    </button>
+  </div>
+
+  <!-- Clone from GitHub modal -->
+  <div id="clone-modal">
+    <div class="clone-modal-content">
+      <h3>Clone from GitHub</h3>
+      <div class="clone-tabs">
+        <button class="clone-tab active" data-tab="url">Paste URL</button>
+        <button class="clone-tab" data-tab="list">My repos</button>
+      </div>
+      <div class="clone-tab-body" data-panel="url">
+        <input type="text" id="clone-url-input" placeholder="owner/repo, https://github.com/owner/repo, or git@github.com:owner/repo.git" spellcheck="false">
+        <div class="clone-url-preview" id="clone-url-preview"></div>
+      </div>
+      <div class="clone-tab-body hidden" data-panel="list">
+        <input type="text" id="clone-repo-filter" placeholder="Filter repos..." spellcheck="false">
+        <div id="clone-repo-list"><div class="clone-repo-loading">Loading your repos…</div></div>
+      </div>
+      <div class="wt-form-group clone-dest-row">
+        <label>Clone into</label>
+        <div class="clone-dest-inner">
+          <input type="text" id="clone-dest-text" readonly placeholder="Choose a folder...">
+          <button id="clone-pick-dest-btn" type="button">Choose folder…</button>
+        </div>
+        <div class="clone-target-preview" id="clone-target-preview"></div>
+      </div>
+      <div class="wt-error" id="clone-error"></div>
+      <div class="wt-modal-buttons">
+        <button id="clone-cancel">Cancel</button>
+        <button id="clone-btn" disabled>Clone</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Worktree create modal -->
   <div id="wt-create-modal">
     <div class="wt-modal-content">

--- a/main/github.js
+++ b/main/github.js
@@ -1,7 +1,18 @@
 const path = require('path');
-const { resolveInDir, execFileAsync, fsp, errMsg } = require('./utils');
+const { resolveInDir, execFileAsync, fsp, errMsg, pathExists } = require('./utils');
 const { getTodoDir } = require('./todo');
 const { getGitInfo } = require('./projects');
+
+// gh prints various phrasings on missing/expired credentials; match the common ones.
+function isAuthError(err) {
+  const combined = ((err.stderr || '') + (err.message || '')).toLowerCase();
+  return combined.includes('not logged') || combined.includes('authentication') || combined.includes('gh auth');
+}
+
+// owner/repo per GitHub's allowed characters; rejects leading dashes so `gh` can't
+// interpret repoRef as a flag (execFileAsync prevents shell injection, but `gh`
+// itself still parses leading-dash tokens as options).
+const REPO_REF_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]+$/;
 
 function register({ ipcMain }) {
   ipcMain.handle('gh:auth-status', async (_event, workDir) => {
@@ -25,6 +36,43 @@ function register({ ipcMain }) {
       } catch {}
     }
     return { authenticated, user, isGitHubRepo, repo };
+  });
+
+  ipcMain.handle('gh:list-repos', async () => {
+    try {
+      const { stdout } = await execFileAsync('gh', [
+        'repo', 'list', '--limit', '100',
+        '--json', 'nameWithOwner,description,visibility,updatedAt,isPrivate,isFork,sshUrl,url',
+      ], { encoding: 'utf-8', timeout: 20000 });
+      return { ok: true, repos: JSON.parse(stdout) };
+    } catch (err) {
+      if (isAuthError(err)) {
+        return { ok: false, error: 'Not authenticated with GitHub. Run `gh auth login` in a terminal.', needsAuth: true };
+      }
+      return { ok: false, error: errMsg(err) };
+    }
+  });
+
+  ipcMain.handle('gh:clone', async (_event, repoRef, targetDir) => {
+    try {
+      if (!repoRef || !targetDir) return { ok: false, error: 'Missing repo or target directory.' };
+      if (typeof repoRef !== 'string' || !REPO_REF_RE.test(repoRef)) {
+        return { ok: false, error: 'Invalid repo reference.' };
+      }
+      if (typeof targetDir !== 'string' || !path.isAbsolute(targetDir)) {
+        return { ok: false, error: 'Target must be an absolute path.' };
+      }
+      if (await pathExists(targetDir)) {
+        return { ok: false, error: `Target directory already exists: ${targetDir}` };
+      }
+      await execFileAsync('gh', ['repo', 'clone', repoRef, targetDir], { encoding: 'utf-8', timeout: 300000 });
+      return { ok: true, path: targetDir };
+    } catch (err) {
+      if (isAuthError(err)) {
+        return { ok: false, error: 'Not authenticated with GitHub. Run `gh auth login` in a terminal.', needsAuth: true };
+      }
+      return { ok: false, error: errMsg(err) };
+    }
   });
 
   ipcMain.handle('gh:pr-list', async (_event, workDir, state) => {

--- a/main/projects.js
+++ b/main/projects.js
@@ -50,6 +50,16 @@ async function getGitInfo(projectPath) {
   }
 }
 
+async function addProjectByPath(app, folderPath) {
+  const projects = await loadProjects(app);
+  const existing = projects.find((p) => p.path === folderPath);
+  if (existing) return existing;
+  const project = { path: folderPath, name: path.basename(folderPath) };
+  projects.push(project);
+  await saveProjects(app, projects);
+  return project;
+}
+
 function register({ ipcMain, app, dialog, BrowserWindow }) {
   ipcMain.handle('projects:list', async () => {
     const projects = await loadProjects(app);
@@ -62,13 +72,25 @@ function register({ ipcMain, app, dialog, BrowserWindow }) {
       properties: ['openDirectory', 'createDirectory'],
     });
     if (canceled || filePaths.length === 0) return null;
-    const folderPath = filePaths[0];
-    const projects = await loadProjects(app);
-    if (projects.some((p) => p.path === folderPath)) return null;
-    const project = { path: folderPath, name: path.basename(folderPath) };
-    projects.push(project);
-    await saveProjects(app, projects);
-    return project;
+    return addProjectByPath(app, filePaths[0]);
+  });
+
+  ipcMain.handle('projects:pick-clone-dir', async () => {
+    const win = BrowserWindow.getFocusedWindow();
+    const { canceled, filePaths } = await dialog.showOpenDialog(win, {
+      title: 'Choose where to clone',
+      properties: ['openDirectory', 'createDirectory'],
+    });
+    if (canceled || filePaths.length === 0) return { ok: false };
+    return { ok: true, path: filePaths[0] };
+  });
+
+  ipcMain.handle('projects:add-cloned', async (_event, clonedPath) => {
+    if (!await pathExists(path.join(clonedPath, '.git'))) {
+      return { ok: false, error: 'Cloned folder is not a git repository.' };
+    }
+    const project = await addProjectByPath(app, clonedPath);
+    return { ok: true, project };
   });
 
   ipcMain.handle('projects:remove', async (_event, projectPath) => {

--- a/preload.js
+++ b/preload.js
@@ -10,6 +10,8 @@ contextBridge.exposeInMainWorld('projects', {
   list: () => ipcRenderer.invoke('projects:list'),
   add: () => ipcRenderer.invoke('projects:add'),
   remove: (projectPath) => ipcRenderer.invoke('projects:remove', projectPath),
+  pickCloneDir: () => ipcRenderer.invoke('projects:pick-clone-dir'),
+  addCloned: (clonedPath) => ipcRenderer.invoke('projects:add-cloned', clonedPath),
 });
 
 contextBridge.exposeInMainWorld('skills', {
@@ -107,6 +109,8 @@ contextBridge.exposeInMainWorld('gitOps', {
 
 contextBridge.exposeInMainWorld('github', {
   authStatus: (workDir) => ipcRenderer.invoke('gh:auth-status', workDir),
+  listRepos: () => ipcRenderer.invoke('gh:list-repos'),
+  clone: (repoRef, targetDir) => ipcRenderer.invoke('gh:clone', repoRef, targetDir),
   prList: (workDir, state) => ipcRenderer.invoke('gh:pr-list', workDir, state),
   prView: (workDir, number) => ipcRenderer.invoke('gh:pr-view', workDir, number),
   prForBranch: (workDir) => ipcRenderer.invoke('gh:pr-for-branch', workDir),

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -16,6 +16,7 @@ import { refreshGitHub, showGitHubIssueDetail, initGitHubPanel } from './github-
 import { initGitHubPRs } from './github-prs.js';
 import { refreshTodos, showTodoClosePrompt, updateTodoFocus, initTodoPanel } from './todo-panel.js';
 import { initHoverLink } from './hover-link.js';
+import { initCloneModal } from './clone-modal.js';
 
 // ── Prevent Electron from navigating to dropped files ──
 document.addEventListener('dragover', (e) => e.preventDefault());
@@ -230,6 +231,7 @@ initGitHubPanel({ startTask, switchRightPanelTab });
 initGitHubPRs({ loadProjects, openWorkDir, closeTab, tabsForWorkDir });
 initTodoPanel({ loadProjects, openWorkDir, startTask, showGitHubIssueDetail, switchRightPanelTab, switchToGitHubView });
 initHoverLink();
+initCloneModal({ loadProjects, openWorkDir });
 
 // ── Tab type picker modal handlers ──
 

--- a/renderer/clone-modal.js
+++ b/renderer/clone-modal.js
@@ -1,0 +1,248 @@
+// Clone from GitHub modal — paste URL or pick from your repos, choose dest, clone via gh.
+
+import { modalState } from './state.js';
+import { escHtml, timeAgo } from './utils.js';
+
+const cloneModal = document.getElementById('clone-modal');
+
+let _loadProjects;
+let _openWorkDir;
+let _reposLoaded = false;
+let _repos = [];
+
+function parseRepoRef(input) {
+  const s = (input || '').trim();
+  if (!s) return null;
+  let m;
+  m = s.match(/^git@github\.com:([^/\s]+)\/(.+?)(?:\.git)?\/?$/);
+  if (m) return `${m[1]}/${m[2]}`;
+  m = s.match(/^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+?)(?:\.git)?(?:\/.*)?$/);
+  if (m) return `${m[1]}/${m[2]}`;
+  m = s.match(/^([A-Za-z0-9][\w.-]*)\/([A-Za-z0-9][\w.-]+?)(?:\.git)?$/);
+  if (m) return `${m[1]}/${m[2]}`;
+  return null;
+}
+
+function repoNameFromRef(repoRef) {
+  if (!repoRef) return '';
+  const idx = repoRef.lastIndexOf('/');
+  return idx >= 0 ? repoRef.slice(idx + 1) : repoRef;
+}
+
+function setError(msg) {
+  const el = document.getElementById('clone-error');
+  if (msg) {
+    el.textContent = msg;
+    el.classList.add('visible');
+  } else {
+    el.textContent = '';
+    el.classList.remove('visible');
+  }
+}
+
+function updateTargetPreview() {
+  const preview = document.getElementById('clone-target-preview');
+  const name = repoNameFromRef(modalState.cloneRepoRef);
+  if (modalState.cloneDestParent && name) {
+    preview.textContent = `Will clone into: ${modalState.cloneDestParent}/${name}`;
+    preview.classList.add('visible');
+  } else {
+    preview.textContent = '';
+    preview.classList.remove('visible');
+  }
+}
+
+function updateCloneButton() {
+  const btn = document.getElementById('clone-btn');
+  btn.disabled = modalState.cloneBusy || !modalState.cloneRepoRef || !modalState.cloneDestParent;
+  btn.textContent = modalState.cloneBusy ? 'Cloning…' : 'Clone';
+}
+
+function switchTab(tab) {
+  modalState.cloneSource = tab;
+  document.querySelectorAll('.clone-tab').forEach(t => {
+    t.classList.toggle('active', t.dataset.tab === tab);
+  });
+  document.querySelectorAll('.clone-tab-body').forEach(b => {
+    b.classList.toggle('hidden', b.dataset.panel !== tab);
+  });
+  // Re-derive the active repoRef from whatever the new tab is currently showing,
+  // so state doesn't bleed across tabs.
+  if (tab === 'url') {
+    modalState.cloneRepoRef = parseRepoRef(document.getElementById('clone-url-input').value) || '';
+  } else {
+    const selected = document.querySelector('.clone-repo-row.selected');
+    modalState.cloneRepoRef = selected ? selected.dataset.ref : '';
+    if (!_reposLoaded) loadRepoList();
+  }
+  updateTargetPreview();
+  updateCloneButton();
+}
+
+function renderRepoList(repos, filter) {
+  const list = document.getElementById('clone-repo-list');
+  const q = (filter || '').trim().toLowerCase();
+  const filtered = q
+    ? repos.filter(r => r.nameWithOwner.toLowerCase().includes(q) || (r.description || '').toLowerCase().includes(q))
+    : repos;
+  if (!filtered.length) {
+    list.innerHTML = '<div class="clone-repo-empty">No matching repos.</div>';
+    return;
+  }
+  list.innerHTML = filtered.map(r => {
+    const isPrivate = r.isPrivate || (r.visibility && r.visibility.toUpperCase() === 'PRIVATE');
+    const chip = isPrivate ? 'private' : 'public';
+    const updated = r.updatedAt ? timeAgo(r.updatedAt) : '';
+    return `<div class="clone-repo-row" data-ref="${escHtml(r.nameWithOwner)}">
+      <div class="clone-repo-main">
+        <span class="clone-repo-name">${escHtml(r.nameWithOwner)}</span>
+        <span class="clone-repo-chip ${chip}">${chip}</span>
+        ${r.isFork ? '<span class="clone-repo-chip fork">fork</span>' : ''}
+      </div>
+      ${r.description ? `<div class="clone-repo-desc">${escHtml(r.description)}</div>` : ''}
+      ${updated ? `<div class="clone-repo-meta">updated ${updated}</div>` : ''}
+    </div>`;
+  }).join('');
+}
+
+async function loadRepoList() {
+  const list = document.getElementById('clone-repo-list');
+  list.innerHTML = '<div class="clone-repo-loading">Loading your repos…</div>';
+  const result = await window.github.listRepos();
+  if (!result.ok) {
+    const hint = result.needsAuth ? '<div class="clone-repo-hint">Run <code>gh auth login</code> in a terminal, then try again.</div>' : '';
+    list.innerHTML = `<div class="clone-repo-error">${escHtml(result.error || 'Failed to load repos.')}</div>${hint}`;
+    return;
+  }
+  _repos = result.repos || [];
+  _reposLoaded = true;
+  renderRepoList(_repos, document.getElementById('clone-repo-filter').value);
+}
+
+function selectRepoRef(ref) {
+  modalState.cloneRepoRef = ref;
+  document.querySelectorAll('.clone-repo-row').forEach(el => {
+    el.classList.toggle('selected', el.dataset.ref === ref);
+  });
+  updateTargetPreview();
+  updateCloneButton();
+  setError('');
+}
+
+export function openCloneModal() {
+  modalState.cloneSource = 'url';
+  modalState.cloneRepoRef = '';
+  modalState.cloneDestParent = '';
+  modalState.cloneBusy = false;
+
+  document.getElementById('clone-url-input').value = '';
+  document.getElementById('clone-url-preview').textContent = '';
+  document.getElementById('clone-repo-filter').value = '';
+  document.getElementById('clone-dest-text').value = '';
+  document.getElementById('clone-target-preview').textContent = '';
+  document.getElementById('clone-target-preview').classList.remove('visible');
+  setError('');
+  switchTab('url');
+  updateCloneButton();
+
+  cloneModal.classList.add('active');
+  document.getElementById('clone-url-input').focus();
+}
+
+function closeModal() {
+  cloneModal.classList.remove('active');
+}
+
+async function doClone() {
+  if (modalState.cloneBusy) return;
+  const ref = modalState.cloneRepoRef;
+  const destParent = modalState.cloneDestParent;
+  if (!ref || !destParent) return;
+  const name = repoNameFromRef(ref);
+  const targetDir = `${destParent}/${name}`;
+
+  modalState.cloneBusy = true;
+  updateCloneButton();
+  setError('');
+
+  const cloneResult = await window.github.clone(ref, targetDir);
+  if (!cloneResult.ok) {
+    modalState.cloneBusy = false;
+    updateCloneButton();
+    setError(cloneResult.error || 'Clone failed.');
+    return;
+  }
+
+  const addResult = await window.projects.addCloned(targetDir);
+  modalState.cloneBusy = false;
+  if (!addResult.ok) {
+    setError(addResult.error || 'Cloned, but failed to register project.');
+    updateCloneButton();
+    return;
+  }
+
+  closeModal();
+  await _loadProjects();
+  _openWorkDir(targetDir);
+}
+
+export function initCloneModal({ loadProjects, openWorkDir }) {
+  _loadProjects = loadProjects;
+  _openWorkDir = openWorkDir;
+
+  document.querySelectorAll('.clone-tab').forEach(t => {
+    t.addEventListener('click', () => switchTab(t.dataset.tab));
+  });
+
+  const urlInput = document.getElementById('clone-url-input');
+  urlInput.addEventListener('input', () => {
+    const parsed = parseRepoRef(urlInput.value);
+    const preview = document.getElementById('clone-url-preview');
+    if (urlInput.value.trim() && parsed) {
+      preview.textContent = `Will clone: ${parsed}`;
+      preview.classList.remove('error');
+      modalState.cloneRepoRef = parsed;
+    } else if (urlInput.value.trim()) {
+      preview.textContent = 'Could not parse repo. Use owner/repo or a github.com URL.';
+      preview.classList.add('error');
+      modalState.cloneRepoRef = '';
+    } else {
+      preview.textContent = '';
+      preview.classList.remove('error');
+      modalState.cloneRepoRef = '';
+    }
+    updateTargetPreview();
+    updateCloneButton();
+    setError('');
+  });
+  urlInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !document.getElementById('clone-btn').disabled) doClone();
+  });
+
+  document.getElementById('clone-repo-filter').addEventListener('input', (e) => {
+    if (_reposLoaded) renderRepoList(_repos, e.target.value);
+  });
+
+  document.getElementById('clone-repo-list').addEventListener('click', (e) => {
+    const row = e.target.closest('.clone-repo-row');
+    if (!row) return;
+    selectRepoRef(row.dataset.ref);
+  });
+
+  document.getElementById('clone-pick-dest-btn').addEventListener('click', async () => {
+    const result = await window.projects.pickCloneDir();
+    if (!result.ok) return;
+    modalState.cloneDestParent = result.path;
+    document.getElementById('clone-dest-text').value = result.path;
+    updateTargetPreview();
+    updateCloneButton();
+    setError('');
+  });
+
+  document.getElementById('clone-cancel').addEventListener('click', closeModal);
+  document.getElementById('clone-btn').addEventListener('click', doClone);
+
+  cloneModal.addEventListener('click', (e) => {
+    if (e.target === cloneModal && !modalState.cloneBusy) closeModal();
+  });
+}

--- a/renderer/sidebar.js
+++ b/renderer/sidebar.js
@@ -2,6 +2,7 @@
 
 import { SVG_OCTOCAT, SVG_GIT_LOGO, SVG_FOLDER, SVG_GIT_BRANCH, divergenceBadges } from './utils.js';
 import { updateNotifUI } from './notifications.js';
+import { openCloneModal } from './clone-modal.js';
 
 // ── DOM refs (queried once at module level) ──
 const projectList = document.getElementById('project-list');
@@ -153,9 +154,32 @@ export function initSidebar({ openWorkDir, openWorktreeCreateModal, showWorktree
   _showWorktreeContextMenu = showWorktreeContextMenu;
   _openProjectScope = openProjectScope;
 
-  addBtn.addEventListener('click', async () => {
-    const result = await window.projects.add();
-    if (result) loadProjects();
+  const addMenu = document.getElementById('add-project-menu');
+  function closeAddMenu() { addMenu.classList.remove('active'); }
+
+  addBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (addMenu.classList.contains('active')) { closeAddMenu(); return; }
+    const rect = addBtn.getBoundingClientRect();
+    addMenu.style.top = `${rect.bottom + 4}px`;
+    addMenu.style.left = `${rect.left}px`;
+    addMenu.classList.add('active');
+  });
+
+  addMenu.addEventListener('click', async (e) => {
+    const item = e.target.closest('.add-project-menu-item');
+    if (!item) return;
+    closeAddMenu();
+    if (item.dataset.action === 'open-folder') {
+      const result = await window.projects.add();
+      if (result) loadProjects();
+    } else if (item.dataset.action === 'clone-github') {
+      openCloneModal();
+    }
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!e.target.closest('#add-project-menu') && !e.target.closest('#add-project-btn')) closeAddMenu();
   });
 
   projectList.addEventListener('click', async (e) => {

--- a/renderer/state.js
+++ b/renderer/state.js
@@ -36,6 +36,10 @@ export const modalState = {
   wtMergeAlreadyMerged: false,
   wtMergeDone: false,
   wtMergeFeatureBranch: null,
+  cloneSource: 'url',         // 'url' | 'list' — current tab in clone modal
+  cloneRepoRef: '',           // parsed/selected owner/repo
+  cloneDestParent: '',        // chosen parent directory (absolute)
+  cloneBusy: false,           // true while a clone is in-flight
 };
 
 // ── File explorer state ─────────────────────────────────────────

--- a/styles.css
+++ b/styles.css
@@ -3538,3 +3538,209 @@
     .gh-file-dels { color: #f85149; }
     .gh-file-name { color: #ccc; overflow: hidden; text-overflow: ellipsis; }
 
+    /* Add-project popover (anchored off the sidebar + button) */
+    #add-project-menu {
+      display: none;
+      position: fixed;
+      background: #252525;
+      border: 1px solid #3a3a3a;
+      border-radius: 6px;
+      padding: 4px;
+      min-width: 200px;
+      z-index: 200;
+      box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+    }
+    #add-project-menu.active { display: block; }
+    .add-project-menu-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      background: none;
+      border: none;
+      color: #ccc;
+      padding: 7px 10px;
+      font-size: 0.82rem;
+      text-align: left;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+    .add-project-menu-item:hover { background: #333; color: #fff; }
+
+    /* Clone from GitHub modal */
+    #clone-modal {
+      display: none;
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(0,0,0,0.6);
+      z-index: 150;
+      align-items: center;
+      justify-content: center;
+    }
+    #clone-modal.active { display: flex; }
+    .clone-modal-content {
+      background: #252525;
+      border: 1px solid #3a3a3a;
+      border-radius: 10px;
+      padding: 24px;
+      min-width: 480px;
+      max-width: 560px;
+      width: 560px;
+    }
+    .clone-modal-content h3 {
+      margin: 0 0 14px 0;
+      font-size: 0.95rem;
+      color: #ccc;
+    }
+    .clone-tabs {
+      display: flex;
+      gap: 2px;
+      border-bottom: 1px solid #3a3a3a;
+      margin-bottom: 14px;
+    }
+    .clone-tab {
+      background: none;
+      border: none;
+      color: #888;
+      padding: 8px 14px;
+      font-size: 0.82rem;
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -1px;
+    }
+    .clone-tab:hover { color: #ccc; }
+    .clone-tab.active { color: #4a9eff; border-bottom-color: #4a9eff; }
+    .clone-tab-body.hidden { display: none; }
+    #clone-url-input,
+    #clone-repo-filter,
+    #clone-dest-text {
+      width: 100%;
+      background: #1e1e1e;
+      border: 1px solid #3a3a3a;
+      color: #ddd;
+      padding: 8px 10px;
+      border-radius: 6px;
+      font-size: 0.85rem;
+      outline: none;
+      box-sizing: border-box;
+    }
+    #clone-url-input:focus,
+    #clone-repo-filter:focus { border-color: #4a9eff; }
+    .clone-url-preview {
+      font-size: 0.78rem;
+      color: #8bbd8b;
+      margin-top: 6px;
+      min-height: 16px;
+    }
+    .clone-url-preview.error { color: #e55; }
+    #clone-repo-list {
+      margin-top: 10px;
+      max-height: 280px;
+      overflow-y: auto;
+      border: 1px solid #333;
+      border-radius: 6px;
+      background: #1e1e1e;
+    }
+    .clone-repo-loading,
+    .clone-repo-empty {
+      padding: 14px;
+      font-size: 0.82rem;
+      color: #888;
+      text-align: center;
+    }
+    .clone-repo-error {
+      padding: 14px;
+      font-size: 0.82rem;
+      color: #e55;
+    }
+    .clone-repo-hint {
+      padding: 0 14px 14px;
+      font-size: 0.78rem;
+      color: #888;
+    }
+    .clone-repo-hint code {
+      background: #2a2a2a;
+      padding: 1px 5px;
+      border-radius: 3px;
+      color: #ddd;
+    }
+    .clone-repo-row {
+      padding: 8px 10px;
+      border-bottom: 1px solid #2a2a2a;
+      cursor: pointer;
+    }
+    .clone-repo-row:last-child { border-bottom: none; }
+    .clone-repo-row:hover { background: #262626; }
+    .clone-repo-row.selected { background: #2a3a52; }
+    .clone-repo-main {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .clone-repo-name {
+      font-size: 0.85rem;
+      color: #ddd;
+      font-weight: 500;
+    }
+    .clone-repo-chip {
+      font-size: 0.68rem;
+      padding: 1px 7px;
+      border-radius: 10px;
+      text-transform: lowercase;
+      letter-spacing: 0.02em;
+      border: 1px solid;
+    }
+    .clone-repo-chip.public { color: #8bbd8b; border-color: #3a5a3a; }
+    .clone-repo-chip.private { color: #d29922; border-color: #6a5a2a; }
+    .clone-repo-chip.fork { color: #8ba0d2; border-color: #3a4a6a; }
+    .clone-repo-desc {
+      font-size: 0.76rem;
+      color: #aaa;
+      margin-top: 3px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .clone-repo-meta {
+      font-size: 0.72rem;
+      color: #777;
+      margin-top: 2px;
+    }
+    .clone-dest-row { margin-top: 14px; }
+    .clone-dest-inner {
+      display: flex;
+      gap: 6px;
+    }
+    .clone-dest-inner #clone-dest-text { flex: 1; cursor: default; }
+    #clone-pick-dest-btn {
+      background: #2a2a2a;
+      border: 1px solid #3a3a3a;
+      color: #ccc;
+      padding: 8px 14px;
+      border-radius: 6px;
+      font-size: 0.8rem;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    #clone-pick-dest-btn:hover { background: #333; color: #fff; }
+    .clone-target-preview {
+      font-size: 0.76rem;
+      color: #888;
+      margin-top: 6px;
+      font-family: Menlo, Monaco, "Courier New", monospace;
+      display: none;
+    }
+    .clone-target-preview.visible { display: block; }
+    #clone-btn {
+      background: #4a9eff;
+      border-color: #4a9eff;
+      color: #fff;
+    }
+    #clone-btn:hover:not(:disabled) { background: #3a8eef; }
+    #clone-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    #clone-cancel {
+      background: none;
+      color: #888;
+    }
+    #clone-cancel:hover { background: #2a2a2a; color: #ccc; }
+


### PR DESCRIPTION
## Summary
- Add `gh:list-repos` and `gh:clone` IPC handlers in `main/github.js` with auth error detection and repo ref validation.
- Add `projects:pick-clone-dir` and `projects:add-cloned` in `main/projects.js` to pick a destination and register cloned repos as projects.
- New `renderer/clone-modal.js` with URL and "My repos" tabs plus destination picker, wired into the sidebar.
- Expose the new methods on the preload `github` / `projects` namespaces and update styles/markup for the modal.

## Why
Previously the only way to turn a GitHub repo into a Braska project was to clone it manually and then add the directory. This adds a first-class "Clone from GitHub" flow so a user can go from a GitHub URL (or their own repo list) to a registered Braska project in one step, with validation and clear auth feedback when `gh` isn't signed in.

## Notes
- Uses `execFileAsync` with argument arrays throughout — no shell interpolation, and repo refs are validated before being passed to `gh`.
- The "My repos" tab relies on `gh auth status`; the modal surfaces the auth error inline rather than failing silently.