### PR TITLE
Prevent duplicate reviewer tabs and fix agent name

### DIFF
--- a/renderer/journey-zone.js
+++ b/renderer/journey-zone.js
@@ -176,7 +176,13 @@ async function _handleJourneyAction(action, btn) {
     });
 
   } else if (action === 'review') {
-    _startTask?.('__CLAUDE__', workDir, { initialPrompt: REVIEW_LOOP_PROMPT });
+    for (const tab of tabState.tabs.values()) {
+      if (tab.agentName === 'reviewer' && tab.workDir === workDir) {
+        _showChangesStatus?.('Reviewer already running', 'error');
+        return;
+      }
+    }
+    _startTask?.('reviewer', workDir, { initialPrompt: REVIEW_LOOP_PROMPT });
 
   } else if (action === 'pull') {
     btn.disabled = true;


### PR DESCRIPTION
## Summary
- Guard the journey-zone `review` action against spawning more than one reviewer tab per worktree.
- Show a changes-panel status message ("Reviewer already running") when a duplicate launch is attempted.
- Spawn the review task with the `reviewer` agent name instead of the generic `__CLAUDE__` sentinel.

## Why
Clicking the review action repeatedly would stack multiple reviewer instances on the same worktree, wasting resources and confusing the tab list. Using the proper `reviewer` agent name also ensures the tab is recognizable and that the existing-instance check has something concrete to match against.

## Notes
- Duplicate detection matches on both `agentName === 'reviewer'` and `workDir`, so other worktrees can still launch their own reviewer independently.