### PR TITLE
Show stale-main indicators and auto-fetch remote refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ main/
   git-read.js               — Status, diff, log, worktree-metrics (6 handlers)
   git-ops.js                — Stage/commit/push, branch, stash, amend/revert (21 handlers)
   git-worktree.js           — Pull-latest-main, worktree CRUD, merge ops (10 handlers)
+  git-fetcher.js            — Background fetch scheduler (startup + focus + 5-min interval, 60s per-project debounce)
   github.js                 — All gh:* CLI wrappers (18 handlers)
   migration.js              — One-time data migration from legacy app names
 

--- a/main/git-fetcher.js
+++ b/main/git-fetcher.js
@@ -1,0 +1,65 @@
+// Background git fetch scheduler. Runs shortly after startup, on window focus,
+// and every 5 minutes while a window is focused. Enforces a per-project 60s
+// debounce so rapid triggers don't thrash. Broadcasts 'git:fetched' to the
+// renderer after each successful fetch so stale-main indicators update.
+// Never pulls — only updates remote-tracking refs.
+
+const path = require('path');
+const { execFileAsync, pathExists } = require('./utils');
+const { loadProjects } = require('./projects');
+
+const DEBOUNCE_MS = 60 * 1000;
+const INTERVAL_MS = 5 * 60 * 1000;
+const STARTUP_DELAY_MS = 2000;
+
+const state = new Map(); // projectPath -> { lastFetchAt, inFlight }
+
+async function fetchProject(BrowserWindow, projectPath) {
+  const s = state.get(projectPath) || { lastFetchAt: 0, inFlight: false };
+  if (s.inFlight) return;
+  if (Date.now() - s.lastFetchAt < DEBOUNCE_MS) return;
+  if (!await pathExists(path.join(projectPath, '.git'))) return;
+  s.inFlight = true;
+  state.set(projectPath, s);
+  try {
+    await execFileAsync('git', ['fetch', '--all', '--prune'], {
+      cwd: projectPath,
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    s.lastFetchAt = Date.now();
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.webContents.send('git:fetched', projectPath);
+    }
+  } catch (err) {
+    // Offline / auth-missing — don't notify the user, but surface real bugs
+    // (missing git, ENOENT, etc) to the dev console.
+    if (err && err.code !== 'ENOENT' && !/could not resolve host|authentication|network/i.test(String(err.message || ''))) {
+      console.warn('[Braska git-fetcher] fetch failed for', projectPath, err.message || err);
+    }
+  } finally {
+    s.inFlight = false;
+    state.set(projectPath, s);
+  }
+}
+
+async function fetchAllKnownProjects(app, BrowserWindow) {
+  try {
+    const projects = await loadProjects(app);
+    for (const p of projects) fetchProject(BrowserWindow, p.path);
+  } catch (err) {
+    console.error('[Braska git-fetcher] fetchAllKnownProjects failed:', err);
+  }
+}
+
+function register({ app, BrowserWindow }) {
+  setTimeout(() => fetchAllKnownProjects(app, BrowserWindow), STARTUP_DELAY_MS);
+
+  setInterval(() => {
+    if (BrowserWindow.getFocusedWindow()) fetchAllKnownProjects(app, BrowserWindow);
+  }, INTERVAL_MS);
+
+  app.on('browser-window-focus', () => fetchAllKnownProjects(app, BrowserWindow));
+}
+
+module.exports = { register, fetchProject, fetchAllKnownProjects };

--- a/main/git-read.js
+++ b/main/git-read.js
@@ -86,6 +86,22 @@ function register({ ipcMain }) {
 
       // Divergence vs local main + push/pull sync vs origin
       let mainDivergence = null;
+      let mainStale = null;
+      // Stale-main check runs independently of current-branch state so it
+      // works on detached HEAD too.
+      try {
+        const fast = { ...opts, timeout: 5000 };
+        const defaultBranch = await detectDefaultBranch(workDir);
+        const remoteMain = `origin/${defaultBranch}`;
+        await execFileAsync('git', ['rev-parse', '--verify', remoteMain], fast);
+        const { stdout } = await execFileAsync('git', ['rev-list', '--left-right', '--count', `${defaultBranch}...${remoteMain}`], fast);
+        const [localAheadStr, originAheadStr] = stdout.trim().split('\t');
+        mainStale = {
+          originAhead: parseInt(originAheadStr, 10) || 0,
+          localAhead: parseInt(localAheadStr, 10) || 0,
+          branch: defaultBranch,
+        };
+      } catch {}
       try {
         const fast = { ...opts, timeout: 5000 };
         const currentBranch = branch;
@@ -116,7 +132,7 @@ function register({ ipcMain }) {
         } catch {}
       } catch { /* non-critical */ }
 
-      return { isGit: true, branch, unstaged, staged, untracked, conflicted, mainDivergence };
+      return { isGit: true, branch, unstaged, staged, untracked, conflicted, mainDivergence, mainStale };
     } catch {
       return { isGit: false, unstaged: [], staged: [], untracked: [] };
     }
@@ -129,8 +145,23 @@ function register({ ipcMain }) {
 
       const defaultBranch = await detectDefaultBranch(projectPath);
 
+      // Project-wide: is local default-branch behind origin/default-branch?
+      let mainStale = null;
+      try {
+        const remoteMain = `origin/${defaultBranch}`;
+        const optsRoot = { cwd: projectPath, encoding: 'utf-8', timeout: 5000 };
+        await execFileAsync('git', ['rev-parse', '--verify', remoteMain], optsRoot);
+        const { stdout } = await execFileAsync('git', ['rev-list', '--left-right', '--count', `${defaultBranch}...${remoteMain}`], optsRoot);
+        const [localAheadStr, originAheadStr] = stdout.trim().split('\t');
+        mainStale = {
+          originAhead: parseInt(originAheadStr, 10) || 0,
+          localAhead: parseInt(localAheadStr, 10) || 0,
+          branch: defaultBranch,
+        };
+      } catch {}
+
       const results = await Promise.all(info.worktrees.map(async (wt) => {
-        const m = { path: wt.path, changed: 0, untracked: 0, ahead: 0, behind: 0, pushAhead: 0, pushBehind: 0 };
+        const m = { path: wt.path, changed: 0, untracked: 0, ahead: 0, behind: 0, pushAhead: 0, pushBehind: 0, mainStale, isMain: !!wt.isMain };
         const opts = { cwd: wt.path, encoding: 'utf-8', timeout: 10000 };
         try {
           const { stdout } = await execFileAsync('git', ['status', '--porcelain'], opts);

--- a/main/index.js
+++ b/main/index.js
@@ -170,6 +170,7 @@ app.whenReady().then(async () => {
   require('./git-read').register(deps);
   require('./git-ops').register(deps);
   require('./git-worktree').register(deps);
+  require('./git-fetcher').register(deps);
   require('./github').register(deps);
   require('./browser-view').register(deps);
 

--- a/main/projects.js
+++ b/main/projects.js
@@ -100,4 +100,4 @@ function register({ ipcMain, app, dialog, BrowserWindow }) {
   });
 }
 
-module.exports = { register, getGitInfo };
+module.exports = { register, getGitInfo, loadProjects };

--- a/preload.js
+++ b/preload.js
@@ -105,6 +105,7 @@ contextBridge.exposeInMainWorld('gitOps', {
   discard: (workDir, filePaths) => ipcRenderer.invoke('git:discard', workDir, filePaths),
   amend: (workDir, message) => ipcRenderer.invoke('git:amend', workDir, message),
   revertCommit: (workDir, hash) => ipcRenderer.invoke('git:revert-commit', workDir, hash),
+  onFetched: (cb) => ipcRenderer.on('git:fetched', (_ev, projectPath) => cb(projectPath)),
 });
 
 contextBridge.exposeInMainWorld('github', {

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -214,6 +214,15 @@ window.todo.onChange(() => {
   }, 300);
 });
 
+// Background fetch completed — update stale-main indicators.
+window.gitOps.onFetched(() => {
+  clearTimeout(watchState.fetchRefreshDebounce);
+  watchState.fetchRefreshDebounce = setTimeout(() => {
+    refreshWorktreeMetrics();
+    if (tabState.activeWorkDir) refreshChanges(tabState.activeWorkDir);
+  }, 300);
+});
+
 // ── Initialize all modules ──
 
 // Modules that need cross-module function references

--- a/renderer/git-changes.js
+++ b/renderer/git-changes.js
@@ -62,14 +62,22 @@ gitState.changesTreeView = localStorage.getItem('braska-changes-tree-view') === 
 const branchSubtitleEl = document.getElementById('branch-subtitle');
 
 // ── Helper: update branch subtitle with divergence info ─────────
-function updateMainDivergence(div) {
+function updateMainDivergence(status) {
   if (!branchSubtitleEl) return;
-  if (!div) { branchSubtitleEl.innerHTML = ''; return; }
+  const div = status?.mainDivergence;
+  const stale = status?.mainStale;
+  const onMain = stale && status?.branch === stale.branch;
   const parts = [];
-  if (div.ahead > 0) parts.push(`<span class="branch-ahead">${div.ahead} ahead</span>`);
-  if (div.behind > 0) parts.push(`<span class="branch-behind">${div.behind} behind main</span>`);
-  if (div.pushAhead > 0) parts.push(`<span class="branch-unpushed">${div.pushAhead} unpushed</span>`);
-  if (div.pushBehind > 0) parts.push(`<span class="branch-unpulled">${div.pushBehind} unpulled</span>`);
+  if (div?.ahead > 0) parts.push(`<span class="branch-ahead">${div.ahead} ahead</span>`);
+  if (div?.behind > 0) parts.push(`<span class="branch-behind">${div.behind} behind main</span>`);
+  if (div?.pushAhead > 0) parts.push(`<span class="branch-unpushed">${div.pushAhead} unpushed</span>`);
+  if (div?.pushBehind > 0) parts.push(`<span class="branch-unpulled">${div.pushBehind} unpulled</span>`);
+  // Local main is stale vs origin/main. On main itself this duplicates pushBehind,
+  // so only surface it when on a feature branch.
+  if (!onMain && stale?.originAhead > 0) {
+    const n = stale.originAhead;
+    parts.push(`<span class="branch-stale" title="Local ${stale.branch} is ${n} commit${n !== 1 ? 's' : ''} behind origin/${stale.branch}. Pull latest main to refresh.">main is ${n} behind origin</span>`);
+  }
   branchSubtitleEl.innerHTML = parts.join(' · ');
 }
 
@@ -296,7 +304,7 @@ async function _refreshChangesInner(workDir) {
   commitsBody.style.display = '';
 
   // Update main divergence indicator + branch subtitle
-  updateMainDivergence(status.mainDivergence);
+  updateMainDivergence(status);
 
   // Render journey zone cards based on current state
   renderJourneyZone(status);

--- a/renderer/journey-cards.mjs
+++ b/renderer/journey-cards.mjs
@@ -72,6 +72,20 @@ export function computeJourneyCards(status, opts = {}) {
     });
   }
 
+  // ── Priority 4b: Local main is stale vs origin/main ──
+  // Only meaningful on a feature branch — `div.pushBehind` covers the on-main case.
+  const stale = status?.mainStale;
+  const onMain = stale && status?.branch === stale.branch;
+  if (!onMain && stale?.originAhead > 0) {
+    const n = stale.originAhead;
+    cards.push({
+      key: 'stale-main', accent: 'warning',
+      title: `Your main is ${n} behind origin`,
+      tooltip: `Local ${stale.branch} hasn't been updated with ${n} new commit${n !== 1 ? 's' : ''} from GitHub`,
+      buttons: [{ label: 'Update main', action: 'pull-main' }],
+    });
+  }
+
   // ── Priority 5: Ready to share ──
   if (div?.pushAhead > 0 && div.hasUpstream) {
     const btns = [{ label: 'Push', action: 'push', primary: true }];

--- a/renderer/sidebar.js
+++ b/renderer/sidebar.js
@@ -102,7 +102,13 @@ export async function refreshWorktreeMetrics() {
         if (m.changed > 0) fileBadges.push(`<span class="wt-metric changed" title="${m.changed} changed file${m.changed > 1 ? 's' : ''}">${m.changed}M</span>`);
         if (m.untracked > 0) fileBadges.push(`<span class="wt-metric untracked" title="${m.untracked} new file${m.untracked > 1 ? 's' : ''}">${m.untracked}U</span>`);
         const { html: divHtml } = divergenceBadges(m, 'wt-metric');
-        el.innerHTML = fileBadges.join('') + divHtml;
+        // Stale-main indicator — only on the main worktree row, when origin has advanced
+        let staleHtml = '';
+        if (m.isMain && m.mainStale?.originAhead > 0) {
+          const n = m.mainStale.originAhead;
+          staleHtml = `<span class="wt-metric stale" title="${n} new commit${n !== 1 ? 's' : ''} on origin/${m.mainStale.branch} — pull to update">&#8659;${n}</span>`;
+        }
+        el.innerHTML = fileBadges.join('') + divHtml + staleHtml;
       }
     } catch {}
   }

--- a/renderer/state.js
+++ b/renderer/state.js
@@ -56,6 +56,7 @@ export const explorerState = {
 export const watchState = {
   fsWatchDebounce: null,
   todoWatchDebounce: null,
+  fetchRefreshDebounce: null,
 };
 
 // ── GitHub panel state ──────────────────────────────────────────

--- a/styles.css
+++ b/styles.css
@@ -189,6 +189,7 @@
     .wt-metric.behind { color: #f85149; }
     .wt-metric.unpushed { color: #b87fff; }
     .wt-metric.unpulled { color: #b87fff; }
+    .wt-metric.stale { color: #f0883e; background: #3a2414; }
     .worktree-item:hover {
       color: #ccc;
     }
@@ -2086,6 +2087,13 @@
     .branch-behind { color: #f85149; }
     .branch-unpushed { color: #b87fff; }
     .branch-unpulled { color: #b87fff; }
+    .branch-stale {
+      color: #f0883e;
+      background: #3a2414;
+      padding: 1px 6px;
+      border-radius: 8px;
+      cursor: help;
+    }
 
     /* Overflow menu */
     .overflow-menu {


### PR DESCRIPTION
## Summary
- Detect when local `main` is behind `origin/main` and compute `mainStale` in `git:status` and `git:worktree-metrics`.
- Render a stale badge on the main worktree row and a "Your main is N behind origin" journey card with an **Update main** button.
- Add a background fetcher (`main/git-fetcher.js`) that runs `git fetch --all --prune` at startup, on window focus, and every 5 minutes — with a 60 s per-project debounce.
- Auto-refresh sidebar metrics and the changes panel after each fetch via a new `gitOps.onFetched` IPC bridge.

## Why
Stale-main warnings are only useful if the remote refs are current. Previously users had no signal that their local `main` had fallen behind until they manually fetched or pulled, so the existing "pull main" flows were often surprising or ran against stale data. Polling `git fetch` in the background keeps the indicators truthful without the user ever thinking about it.

## Notes
- Fetcher silently ignores offline and auth errors so laptops-on-planes don't get noisy; real bugs (missing git binary, etc.) still log to the dev console.
- Stale-main suppression: the journey card only appears on feature branches — on `main` itself, the existing `pushBehind` badge already conveys the same information.
- No amends or force-pushes — this is a straight publish of the two commits already on the branch.