### PR TITLE
Link branch subtitle to open PR

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -11,9 +11,9 @@ import { updateNotifUI, initNotifications } from './notifications.js';
 import { refreshFileTree, updateFileTreeHighlights, restoreExplorerState, setRightPanelMode, switchRightPanelTab, toggleSidebar, toggleFiletree, initFileExplorer } from './file-explorer.js';
 import { refreshChanges, stageAndPromptCommit, doPullLatestMain, openDiffTab, openBranchModal, doPush, showChangesStatus, switchToGitHubView, initGitChanges, initPostCommitPromptBridge, initGitHubViewBridge } from './git-changes.js';
 // post-commit-prompt.js is superseded by journey-zone.js — kept for reference only
-import { initJourneyZone, renderJourneyZone, onCommitterExit, dismissPostCommitPrompt } from './journey-zone.js';
+import { initJourneyZone, renderJourneyZone, onCommitterExit, onGithubSpecialistExit, dismissPostCommitPrompt } from './journey-zone.js';
 import { refreshGitHub, showGitHubIssueDetail, initGitHubPanel } from './github-panel.js';
-import { initGitHubPRs } from './github-prs.js';
+import { initGitHubPRs, showGitHubPRDetail } from './github-prs.js';
 import { refreshTodos, showTodoClosePrompt, updateTodoFocus, initTodoPanel } from './todo-panel.js';
 import { initHoverLink } from './hover-link.js';
 import { initCloneModal } from './clone-modal.js';
@@ -237,7 +237,7 @@ initFileExplorer({ openFileEditor, openDiffTab, refreshChanges, startTask, refre
 initGitChanges({ refreshFileTree, startTask, loadProjects, switchTab, addTabToOrder, renderTabBar, tabsForWorkDir });
 initPostCommitPromptBridge();
 initGitHubViewBridge({ refreshGitHub, switchRightPanelTab });
-initJourneyZone({ doPush, doPullLatestMain, openBranchModal, refreshChanges, showChangesStatus, startTask, refreshWorktreeMetrics, loadProjects, openWorkDir });
+initJourneyZone({ doPush, doPullLatestMain, openBranchModal, refreshChanges, showChangesStatus, startTask, refreshWorktreeMetrics, loadProjects, openWorkDir, switchToGitHubView, showGitHubPRDetail });
 initGitHubPanel({ startTask, switchRightPanelTab });
 initGitHubPRs({ loadProjects, openWorkDir, closeTab, tabsForWorkDir });
 initTodoPanel({ loadProjects, openWorkDir, startTask, showGitHubIssueDetail, switchRightPanelTab, switchToGitHubView });

--- a/renderer/git-changes.js
+++ b/renderer/git-changes.js
@@ -7,7 +7,7 @@ import { initChangesActions } from './git-changes-actions.js';
 import { initTreeToggle, renderTreeEntries } from './git-changes-tree.js';
 import { computeGraph, renderFullGraphSvg, createCommitEl, createStashEl, GRAPH_ROW_H, GRAPH_COL_W } from './git-changes-graph.js';
 import { showChangesStatus } from './git-changes-status.js';
-import { renderJourneyZone } from './journey-zone.js';
+import { renderJourneyZone, getCachedPRPillHtml } from './journey-zone.js';
 
 // ── Cross-module deps (injected via initGitChanges) ────────────
 let _refreshFileTree = null;
@@ -78,6 +78,8 @@ function updateMainDivergence(status) {
     const n = stale.originAhead;
     parts.push(`<span class="branch-stale" title="Local ${stale.branch} is ${n} commit${n !== 1 ? 's' : ''} behind origin/${stale.branch}. Pull latest main to refresh.">main is ${n} behind origin</span>`);
   }
+  const prPill = getCachedPRPillHtml(tabState.activeWorkDir, status?.branch);
+  if (prPill) parts.push(prPill);
   branchSubtitleEl.innerHTML = parts.join(' · ');
 }
 

--- a/renderer/github-prs.js
+++ b/renderer/github-prs.js
@@ -72,7 +72,7 @@ export async function refreshGitHubPRs(workDir) {
 
 // ── PR detail ──────────────────────────────────────────────────
 
-async function showGitHubPRDetail(workDir, number) {
+export async function showGitHubPRDetail(workDir, number) {
   const content = document.getElementById('gh-content');
   content.innerHTML = '<div class="gh-empty">Loading PR details...</div>';
 

--- a/renderer/journey-zone.js
+++ b/renderer/journey-zone.js
@@ -17,6 +17,52 @@ let _startTask = null;
 let _refreshWorktreeMetrics = null;
 let _loadProjects = null;
 let _openWorkDir = null;
+let _switchToGitHubView = null;
+let _showGitHubPRDetail = null;
+
+// ── PR-for-branch cache ────────────────────────────────────────
+// Keyed by `${workDir}::${branch}`. Value: { pr: { number, url } | null, ts }.
+// TTL 60s. Invalidated on github-specialist exit.
+const _prCache = new Map();
+const _prCacheInflight = new Set();
+const PR_CACHE_TTL_MS = 60 * 1000;
+const _prCacheKey = (workDir, branch) => `${workDir}::${branch}`;
+
+export function getCachedPRPillHtml(workDir, branch) {
+  if (!workDir || !branch) return '';
+  const entry = _prCache.get(_prCacheKey(workDir, branch));
+  if (!entry || !entry.pr) return '';
+  return `<a class="branch-pr-link" data-journey-action="open-pr" title="Open PR #${entry.pr.number} in GitHub panel">PR #${entry.pr.number}</a>`;
+}
+
+async function ensurePRForBranch(workDir, branch) {
+  if (!workDir || !branch) return;
+  const key = _prCacheKey(workDir, branch);
+  const entry = _prCache.get(key);
+  const fresh = entry && (Date.now() - entry.ts) < PR_CACHE_TTL_MS;
+  if (fresh || _prCacheInflight.has(key)) return;
+  _prCacheInflight.add(key);
+  try {
+    const result = await window.github.prForBranch(workDir);
+    const pr = (result && result.ok) ? (result.pr || null) : null;
+    _prCache.set(key, { pr, ts: Date.now() });
+    // If this is still the active worktree + branch, nudge a subtitle re-render
+    // so the new pill appears. refreshChanges is the simplest path.
+    if (tabState.activeWorkDir === workDir && _refreshChanges) _refreshChanges(workDir);
+  } catch {
+    _prCache.set(key, { pr: null, ts: Date.now() });
+  } finally {
+    _prCacheInflight.delete(key);
+  }
+}
+
+export function onGithubSpecialistExit(workDir) {
+  // Invalidate all cached PR entries for this workDir regardless of branch.
+  for (const key of _prCache.keys()) {
+    if (key.startsWith(`${workDir}::`)) _prCache.delete(key);
+  }
+  if (tabState.activeWorkDir === workDir && _refreshChanges) _refreshChanges(workDir);
+}
 
 export function initJourneyZone(deps) {
   _doPush = deps.doPush;
@@ -28,6 +74,16 @@ export function initJourneyZone(deps) {
   _refreshWorktreeMetrics = deps.refreshWorktreeMetrics;
   _loadProjects = deps.loadProjects;
   _openWorkDir = deps.openWorkDir;
+  _switchToGitHubView = deps.switchToGitHubView;
+  _showGitHubPRDetail = deps.showGitHubPRDetail;
+
+  // Delegated click for the PR pill rendered inside #branch-subtitle
+  document.getElementById('branch-subtitle')?.addEventListener('click', (e) => {
+    const link = e.target.closest('[data-journey-action="open-pr"]');
+    if (!link) return;
+    e.preventDefault();
+    _handleJourneyAction('open-pr', link);
+  });
 
   // Branch name click → open branch modal
   document.getElementById('branch-name-btn')?.addEventListener('click', () => {
@@ -78,6 +134,9 @@ export function renderJourneyZone(status) {
   const mergeInfo = gitState.mergedToMain.get(workDir) || null;
   const cards = computeJourneyCards(status, { mergeInfo });
   _renderCards(zone, cards);
+  // Kick off a background check for an open PR on the current branch.
+  // Cache-backed + idempotent; safe to call on every refresh.
+  if (status?.branch) ensurePRForBranch(workDir, status.branch);
 }
 
 // ── Render helper — reconcile cards into the zone DOM ──────────
@@ -264,6 +323,14 @@ async function _handleJourneyAction(action, btn) {
         _showChangesStatus?.('Cleanup failed: ' + (result.error || '').split('\n')[0], 'error');
       }
     } finally { btn.disabled = false; btn.textContent = 'Clean up branch'; }
+
+  } else if (action === 'open-pr') {
+    const branch = document.getElementById('branch-name-btn')?.textContent || '';
+    const cached = _prCache.get(_prCacheKey(workDir, branch));
+    const number = cached?.pr?.number;
+    if (!number || !_switchToGitHubView || !_showGitHubPRDetail) return;
+    _switchToGitHubView(true, { section: 'prs' });
+    setTimeout(() => _showGitHubPRDetail(workDir, number), 100);
 
   } else if (action === 'open-merger') {
     _startTask?.('merger', workDir, {

--- a/renderer/terminals.js
+++ b/renderer/terminals.js
@@ -4,7 +4,7 @@ import { tabState } from './state.js';
 import { addTabToOrder, renderTabBar, switchTab, getDisplayLabel } from './tabs.js';
 import { markTabBusy, clearTabBusy, markTabActivity, busyTabs, busyDebounceTimers, notifDebounceTimers } from './notifications.js';
 import { agentDisplayName, stripAnsi } from './utils.js';
-import { onCommitterExit } from './journey-zone.js';
+import { onCommitterExit, onGithubSpecialistExit } from './journey-zone.js';
 import { renderMarkdown } from './markdown.js';
 import { languageForPath, renderHighlighted } from './code-highlight.js';
 
@@ -120,6 +120,7 @@ export async function startTask(agentName, workDir, options = {}) {
     if (busyTabs.has(id)) clearTabBusy(id);
     if (tabState.activeTabId !== id) markTabActivity(workDir, id, getDisplayLabel(id), `Process exited with code ${code}`);
     if (agentName === 'committer') onCommitterExit(workDir);
+    if (agentName === 'github-specialist') onGithubSpecialistExit(workDir);
     if (workDir === tabState.activeWorkDir) refreshRightPanel(workDir);
   });
   term.onData(data => window.pty.write(id, data));

--- a/styles.css
+++ b/styles.css
@@ -2094,6 +2094,18 @@
       border-radius: 8px;
       cursor: help;
     }
+    .branch-pr-link {
+      color: #79c0ff;
+      background: #142238;
+      padding: 1px 6px;
+      border-radius: 8px;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .branch-pr-link:hover {
+      background: #1f3b64;
+      color: #cce7ff;
+    }
 
     /* Overflow menu */
     .overflow-menu {


### PR DESCRIPTION
## Summary
- Show a "PR #N" pill in the branch subtitle when the current branch has an open PR, next to the existing branch/stale indicators.
- Clicking the pill switches to the GitHub view and opens the PR detail for that number.
- Cache PR lookups per `workDir::branch` for 60s; invalidate automatically when the `github-specialist` agent exits (likely to have opened or updated a PR).
- Minor export plumbing: `showGitHubPRDetail` is now exported from `renderer/github-prs.js` and wired into `initJourneyZone`.

## Why
Once a PR exists for a worktree's branch, there was no at-a-glance way to see it or jump to it from the changes panel — you had to switch to the GitHub view and hunt. Surfacing the PR number inline in the subtitle gives immediate feedback that the branch is on GitHub and a one-click path into the PR detail, matching how the other subtitle badges (stale main, behind origin) already work.

## Notes
- Lookup runs in the background via `window.github.prForBranch(workDir)` on every `renderJourneyZone`, guarded by a cache + in-flight set so repeated refreshes don't spam `gh`.
- Cache is invalidated on `github-specialist` tab exit per worktree, so a newly-opened PR appears on the next status refresh without a full-app reload.
- No main-process or IPC changes — renderer-only.