### PR TITLE
fix: include org and collaborator repos in clone-from-GitHub picker

### DIFF
--- a/main/github.js
+++ b/main/github.js
@@ -40,11 +40,23 @@ function register({ ipcMain }) {
 
   ipcMain.handle('gh:list-repos', async () => {
     try {
+      // REST /user/repos with explicit affiliations so the picker shows org + collaborator repos,
+      // not just the user's own. `gh repo list` alone can't do this in one call.
       const { stdout } = await execFileAsync('gh', [
-        'repo', 'list', '--limit', '100',
-        '--json', 'nameWithOwner,description,visibility,updatedAt,isPrivate,isFork,sshUrl,url',
+        'api', '/user/repos?affiliation=owner,collaborator,organization_member&sort=updated&per_page=100',
       ], { encoding: 'utf-8', timeout: 20000 });
-      return { ok: true, repos: JSON.parse(stdout) };
+      const raw = JSON.parse(stdout);
+      const repos = raw.map(r => ({
+        nameWithOwner: r.full_name,
+        description: r.description,
+        visibility: r.visibility,
+        updatedAt: r.updated_at,
+        isPrivate: r.private,
+        isFork: r.fork,
+        sshUrl: r.ssh_url,
+        url: r.html_url,
+      }));
+      return { ok: true, repos };
     } catch (err) {
       if (isAuthError(err)) {
         return { ok: false, error: 'Not authenticated with GitHub. Run `gh auth login` in a terminal.', needsAuth: true };


### PR DESCRIPTION
## Summary
- Switch `gh:list-repos` from `gh repo list` to `gh api /user/repos` with explicit `affiliation=owner,collaborator,organization_member`
- Map the REST response back to the camelCase fields the clone picker already consumes (`nameWithOwner`, `sshUrl`, `url`, …)

## Why
The clone-from-GitHub picker was only showing repos the user personally owns, because `gh repo list` (with no owner argument) defaults to the authenticated user's own repos. Users couldn't pick repos from organizations they belong to or repos they collaborate on, even though `gh` is authenticated for them. The REST endpoint with an explicit affiliation list returns every repo the user can actually clone, in a single call.

## Notes
- Same 100-item limit and 20s timeout as before
- Field-name mapping keeps the renderer untouched; no UI changes needed
- Auth-error handling (`isAuthError`) still applies — `gh api` surfaces the same error shape