### PR TITLE
[routine] close icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "electron .",
     "postinstall": "electron-rebuild -f -w node-pty",
-    "test": "node --test test/"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/renderer/sidebar.js
+++ b/renderer/sidebar.js
@@ -20,6 +20,7 @@ let _openIssueInPanel;
 // ── SVG icons for section links ──
 const SVG_TODO = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>';
 const SVG_GITHUB = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>';
+const SVG_X_CIRCLE = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>';
 
 // ── Functions ──────────────────────────────────────────────────
 
@@ -61,7 +62,7 @@ export function renderProjects(projects) {
           ${projectIcon}
           <div class="project-name">${p.name}</div>
           ${sectionLinks}
-          <button class="remove-btn" title="Remove project">&times;</button>
+          <button class="remove-btn" title="Remove project">${SVG_X_CIRCLE}</button>
         </div>
         ${worktrees}
       </div>

--- a/specs/spec-20260519-close-icon/research.md
+++ b/specs/spec-20260519-close-icon/research.md
@@ -1,0 +1,90 @@
+# Research: close icon (#37)
+
+## Problem Summary
+
+The "remove project" button in the sidebar project list uses a plain `&times;` HTML entity rendered as a tiny, low-opacity character. Compared to the neighbouring TODO and GitHub SVG icons — which share a consistent 14×14px stroke-based visual language — the close button is:
+
+1. **Too dark at rest:** color `#555`, opacity `0.15`. The section-link icons use opacity `0.5` at rest, giving them much better presence.
+2. **Stylistically inconsistent:** An HTML entity text character beside two SVG icons looks like a bug. It doesn't scale or colour cleanly with `currentColor`.
+3. **Wrong shape:** The neighbouring icons are circular in design (check-in-circle for todos, Octocat disc for GitHub). The issue asks for an "x in a circle" to complete the family.
+
+## Key Findings
+
+### Current close button
+
+**`renderer/sidebar.js` line 64:**
+```html
+<button class="remove-btn" title="Remove project">&times;</button>
+```
+
+**`styles.css` lines 96–109:**
+```css
+.remove-btn {
+  background: none;
+  border: none;
+  color: #555;
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  opacity: 0.15;
+  flex-shrink: 0;
+  transition: opacity 0.2s ease;
+}
+.project-item:hover .remove-btn { opacity: 0.5; }
+.remove-btn:hover { opacity: 1 !important; color: #e55; background: #2a1515; }
+```
+
+### Neighbouring icons
+
+**`renderer/sidebar.js` lines 21–22 (local SVG constants):**
+- `SVG_TODO` — 14×14 stroke `currentColor` circle with checkmark
+- `SVG_GITHUB` — 14×14 fill `currentColor` Octocat disc
+
+**`styles.css` (`.project-section-link` block):**
+```css
+color: #666;       /* base */
+opacity: 0.5;      /* at rest */
+/* on hover: color #ccc, background #2a2a2a, opacity 1 */
+```
+
+## Approaches
+
+### Approach A — Inline SVG in button, tune CSS only
+Replace `&times;` with a feather/lucide `x-circle` SVG (circle + diagonals). Keep the `<button class="remove-btn">` wrapper; update CSS to match section-link opacity/colour. No new constant in utils.js.
+
+**Pro:** Minimal surface area; no new exports; easy to verify.  
+**Con:** SVG string lives in a template literal inside `sidebar.js` like the other two local constants (SVG_TODO/SVG_GITHUB) — that's already the local pattern so not actually a con.
+
+### Approach B — Add SVG_X_CIRCLE to utils.js and import it
+Define constant in utils.js, import in sidebar.js alongside SVG_FOLDER etc.
+
+**Pro:** Follows the utils.js pattern for shared SVG constants.  
+**Con:** YAGNI — this icon is only used in sidebar.js; two other icons (SVG_TODO, SVG_GITHUB) are already defined locally in sidebar.js without going through utils.js, so the established local pattern is fine.
+
+### Approach C — Swap to a CSS-only circle using border-radius + pseudo-element
+Style the button with `border-radius: 50%` and size it to look circular; keep the `×` entity.
+
+**Pro:** No SVG.  
+**Con:** HTML entity doesn't render crisply at 14px; won't inherit `currentColor` cleanly; doesn't match the SVG icon family visually.
+
+## Recommended Approach
+
+**Approach A** — inline SVG `x-circle` as a local constant in `sidebar.js` (matching the SVG_TODO/SVG_GITHUB pattern that is already there), plus CSS updates to `.remove-btn` to match `.project-section-link` opacity/colour.
+
+SVG to use (feather `x-circle`, 14×14):
+```svg
+<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
+```
+
+CSS changes:
+- Remove `font-size` and `padding: 2px 6px` (replace with `padding: 4px` matching section-link)
+- Change `color: #555` → `color: #666`
+- Change `opacity: 0.15` → `opacity: 0.5`
+- Keep hover: red tint (`color: #e55; background: #2a1515; opacity: 1`) — that's intentional UX for destructive action
+
+## Unknowns
+
+- None. The change is CSS + one string replacement in a single file. No interaction with IPC, state, or other subsystems.
+
+No external lookup performed.

--- a/specs/spec-20260519-close-icon/spec.html
+++ b/specs/spec-20260519-close-icon/spec.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Spec — close icon (#37)</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 80ch; margin: 2rem auto; padding: 0 1rem; color: #222; line-height: 1.5; }
+  h1, h2 { border-bottom: 1px solid #ddd; padding-bottom: .25rem; }
+  .meta { color: #777; font-size: .9rem; }
+  .status { font-weight: 600; color: #0d47a1; margin: 0 0 1.5rem; padding: .5rem .9rem; background: #e3f2fd; border-left: 3px solid #1565c0; border-radius: 3px; }
+  blockquote { border-left: 3px solid #888; padding: .25rem .9rem; color: #444; background: #fafafa; }
+  ul.check { list-style: none; padding-left: .5rem; }
+  ul.check ul { padding-left: 1.5rem; margin: .1rem 0; }
+  ul.check li.done { color: #888; text-decoration: line-through; }
+  ul.check li.active { font-weight: bold; }
+  ul.check li.deferred { color: #888; }
+  ul.check li::before { content: "☐ "; }
+  ul.check li.done::before { content: "☑ "; color: #2e7d32; text-decoration: none; }
+  ul.check li.active::before { content: "▶ "; color: #1565c0; }
+  ul.check li.deferred::before { content: "⏸ "; color: #f57c00; text-decoration: none; }
+  .story { display: block; font-style: italic; color: #555; font-size: .9rem; padding-left: 1.5rem; }
+  .testref { display: block; font-family: ui-monospace, "SF Mono", monospace; color: #2e7d32; font-size: .85rem; padding-left: 1.5rem; }
+  .entry { border-left: 2px solid #ccc; padding: .25rem .9rem; margin: .5rem 0; }
+  .entry time { color: #999; font-size: .85rem; display: block; }
+  .entry.dont { border-left-color: #c62828; }
+  .entry.dont strong { color: #c62828; }
+  .assume { padding: .1rem 0; }
+  .assume.uncertain { color: #c62828; }
+  .assume.uncertain::before { content: "⚠ "; }
+  .assume.confident::before { content: "• "; }
+  pre.cmd { background: #f3f3f3; padding: .35rem .6rem; margin: .15rem 0; border-radius: 3px; font-size: .9rem; overflow-x: auto; }
+  code { background: #f3f3f3; padding: 0 .2rem; border-radius: 3px; }
+</style>
+</head>
+<body>
+<h1>close icon</h1>
+<p class="meta">Issue <a href="https://github.com/derek-hobden/braska/issues/37">#37</a> · branch <code>claude/issue-37</code> · started 2026-05-19T12:30:00Z</p>
+<p class="status">Spec drafted; implementation not started.</p>
+
+<h2>Issue body</h2>
+<blockquote>
+  the X to close project should be brighter, same as other symbols next to it (the todo icon and the github icon). it's currently too dark against the background and its just generally bad practice. also, perhaps we can change the icon to an x in a circle, the other icons are also circular so that would look nice.
+</blockquote>
+
+<h2>Chosen approach</h2>
+<p>
+  Replace the <code>&amp;times;</code> HTML entity in the remove button with an inline SVG <code>x-circle</code> icon (feather-style: 14×14px, <code>stroke="currentColor"</code>, circle + two diagonal lines), stored as a local constant <code>SVG_X_CIRCLE</code> in <code>renderer/sidebar.js</code> alongside the existing <code>SVG_TODO</code> and <code>SVG_GITHUB</code> constants. Update the <code>.remove-btn</code> CSS to raise opacity at rest from <code>0.15</code> to <code>0.5</code> and change colour from <code>#555</code> to <code>#666</code>, matching the <code>.project-section-link</code> scheme. Keep the red hover tint — it signals a destructive action and is intentional UX. No changes to IPC, state, or any other file.
+</p>
+
+<h2>Assumptions</h2>
+<ul>
+  <li class="assume confident">The red hover tint (<code>color: #e55; background: #2a1515</code>) on the close button is intentional and should be preserved — it visually distinguishes a destructive action from navigation actions.</li>
+  <li class="assume confident">14×14px is the correct icon size — all neighbouring icons use this size.</li>
+  <li class="assume confident">Padding should change from <code>2px 6px</code> to <code>4px</code> to align with <code>.project-section-link</code> sizing and give the circular SVG equal spacing on all sides.</li>
+  <li class="assume confident">The feather/lucide <code>x-circle</code> path (<code>circle cx="12" cy="12" r="10"</code> + two diagonal lines) is an appropriate "x in a circle" — the same icon family used for SVG_TODO.</li>
+</ul>
+
+<h2>Definition of done</h2>
+<ul>
+  <li>The remove-project button renders an SVG circle with an X inside (not a plain &amp;times; character).</li>
+  <li>The icon is visible at <code>opacity: 0.5</code> when the project row is hovered (not nearly invisible at 0.15).</li>
+  <li>On button hover, the icon turns red (<code>#e55</code>) on a dark background — same destructive-action treatment as before.</li>
+  <li>The SVG scales and colours correctly alongside the TODO and GitHub icons (same 14×14px size, same <code>currentColor</code> approach).</li>
+  <li>No other sidebar elements are visually changed.</li>
+  <li><code>npm test</code> passes.</li>
+</ul>
+
+<h2>Up-front tests</h2>
+<ul>
+  <li><code>test/sidebar.test.js::remove-btn renders SVG not times entity</code> — asserts that <code>renderProjects</code> output contains <code>&lt;svg</code> inside the <code>.remove-btn</code> and does not contain <code>&amp;times;</code>.</li>
+  <li><code>test/sidebar.test.js::remove-btn SVG has circle and x lines</code> — asserts the SVG contains a <code>&lt;circle</code> element and two <code>&lt;line</code> elements.</li>
+</ul>
+
+<h2>Tasks</h2>
+<ul class="check">
+  <li class="active">Write failing tests for the SVG change
+    <span class="story">Story: As a developer, when I run <code>npm test</code> before the fix, the new assertions about SVG content in the remove button fail.</span>
+    <span class="testref">test: test/sidebar.test.js::remove-btn renders SVG not times entity</span>
+  </li>
+  <li>Add <code>SVG_X_CIRCLE</code> constant and update button HTML in <code>renderer/sidebar.js</code>
+    <span class="story">Story: As a user, when I look at the project list, I see a circle-X icon instead of a plain × character next to each project.</span>
+    <span class="testref">test: test/sidebar.test.js::remove-btn renders SVG not times entity</span>
+  </li>
+  <li>Update <code>.remove-btn</code> CSS in <code>styles.css</code> to raise opacity and fix colour
+    <span class="story">Story: As a user, when I hover a project row, the close icon is clearly visible at the same brightness as the todo and github icons beside it.</span>
+  </li>
+</ul>
+
+<h2>Verify</h2>
+<pre class="cmd">npm test</pre>
+
+<h2>Decisions</h2>
+<!-- append entries in ascending chronological order -->
+
+<h2>Don'ts / rejected approaches</h2>
+<div class="entry dont">
+  <strong>Don't</strong> move SVG_X_CIRCLE to utils.js — SVG_TODO and SVG_GITHUB are already defined locally in sidebar.js; this icon is used only there; YAGNI.
+</div>
+<div class="entry dont">
+  <strong>Don't</strong> use a CSS-only circle via <code>border-radius: 50%</code> — the &amp;times; entity doesn't scale cleanly at 14px and won't inherit <code>currentColor</code> the same way.
+</div>
+
+<h2>Course corrections</h2>
+
+<h2>Subagent notes</h2>
+
+<h2>Follow-ups (deferred work)</h2>
+<ul>
+</ul>
+
+<h2>Open questions</h2>
+<ul>
+</ul>
+
+<h2>Verification results</h2>
+<!-- populated by Phase 4; one block per Verify command with exit code and tail of output -->
+
+</body>
+</html>

--- a/specs/spec-20260519-close-icon/spec.html
+++ b/specs/spec-20260519-close-icon/spec.html
@@ -35,7 +35,7 @@
 <body>
 <h1>close icon</h1>
 <p class="meta">Issue <a href="https://github.com/derek-hobden/braska/issues/37">#37</a> · branch <code>claude/issue-37</code> · started 2026-05-19T12:30:00Z</p>
-<p class="status">Spec drafted; implementation not started.</p>
+<p class="status">Implementation complete; all tasks done; awaiting review.</p>
 
 <h2>Issue body</h2>
 <blockquote>
@@ -77,11 +77,11 @@
     <span class="story">Story: As a developer, when I run <code>npm test</code> before the fix, the new assertions about SVG content in the remove button fail.</span>
     <span class="testref">test: test/sidebar.test.js::remove-btn renders SVG not times entity</span>
   </li>
-  <li class="active">Add <code>SVG_X_CIRCLE</code> constant and update button HTML in <code>renderer/sidebar.js</code>
+  <li class="done">Add <code>SVG_X_CIRCLE</code> constant and update button HTML in <code>renderer/sidebar.js</code>
     <span class="story">Story: As a user, when I look at the project list, I see a circle-X icon instead of a plain × character next to each project.</span>
     <span class="testref">test: test/sidebar.test.js::remove-btn renders SVG not times entity</span>
   </li>
-  <li>Update <code>.remove-btn</code> CSS in <code>styles.css</code> to raise opacity and fix colour
+  <li class="done">Update <code>.remove-btn</code> CSS in <code>styles.css</code> to raise opacity and fix colour
     <span class="story">Story: As a user, when I hover a project row, the close icon is clearly visible at the same brightness as the todo and github icons beside it.</span>
   </li>
 </ul>

--- a/specs/spec-20260519-close-icon/spec.html
+++ b/specs/spec-20260519-close-icon/spec.html
@@ -73,11 +73,11 @@
 
 <h2>Tasks</h2>
 <ul class="check">
-  <li class="active">Write failing tests for the SVG change
+  <li class="done">Write failing tests for the SVG change
     <span class="story">Story: As a developer, when I run <code>npm test</code> before the fix, the new assertions about SVG content in the remove button fail.</span>
     <span class="testref">test: test/sidebar.test.js::remove-btn renders SVG not times entity</span>
   </li>
-  <li>Add <code>SVG_X_CIRCLE</code> constant and update button HTML in <code>renderer/sidebar.js</code>
+  <li class="active">Add <code>SVG_X_CIRCLE</code> constant and update button HTML in <code>renderer/sidebar.js</code>
     <span class="story">Story: As a user, when I look at the project list, I see a circle-X icon instead of a plain × character next to each project.</span>
     <span class="testref">test: test/sidebar.test.js::remove-btn renders SVG not times entity</span>
   </li>

--- a/specs/spec-20260519-close-icon/spec.html
+++ b/specs/spec-20260519-close-icon/spec.html
@@ -113,7 +113,14 @@
 </ul>
 
 <h2>Verification results</h2>
-<!-- populated by Phase 4; one block per Verify command with exit code and tail of output -->
+<p>Run: 2026-05-19</p>
+<p><strong>npm test</strong> — exit 0 — 22 tests, 22 pass, 0 fail</p>
+<pre class="cmd">ok 1 - git:pull handler (5 subtests)
+ok 2 - git:pull-latest-main handler (4 subtests)
+ok 3 - test/helpers.js
+ok 4 - computeJourneyCards (9 subtests)
+ok 5 - remove-btn (3 subtests)
+# tests 22  # pass 22  # fail 0</pre>
 
 </body>
 </html>

--- a/specs/spec-20260519-close-icon/verify-results.md
+++ b/specs/spec-20260519-close-icon/verify-results.md
@@ -1,0 +1,28 @@
+# Verify results for close icon (#37)
+
+Run date: 2026-05-19
+
+## `npm test`
+
+**Exit code: 0**
+
+```
+TAP version 13
+ok 1 - git:pull handler           (5 subtests)
+ok 2 - git:pull-latest-main handler (4 subtests)
+ok 3 - test/helpers.js
+ok 4 - computeJourneyCards        (9 subtests)
+ok 5 - remove-btn                 (3 subtests)
+
+1..5
+# tests 22
+# suites 4
+# pass 22
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 179.63929
+```
+
+All checks green. No deferred tasks. No uncertain assumptions. No open questions.

--- a/styles.css
+++ b/styles.css
@@ -96,17 +96,19 @@
     .remove-btn {
       background: none;
       border: none;
-      color: #555;
-      font-size: 0.9rem;
+      color: #666;
       cursor: pointer;
-      padding: 2px 6px;
+      padding: 4px;
       border-radius: 4px;
-      opacity: 0.15;
+      opacity: 0.5;
       flex-shrink: 0;
-      transition: opacity 0.2s ease;
+      transition: opacity 0.2s ease, color 0.15s ease, background 0.15s ease;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
     }
-    .project-item:hover .remove-btn { opacity: 0.5; }
-    .remove-btn:hover { opacity: 1 !important; color: #e55; background: #2a1515; }
+    .project-item:hover .remove-btn { opacity: 1; }
+    .remove-btn:hover { color: #e55 !important; background: #2a1515; }
     #empty-sidebar {
       padding: 16px;
       color: #555;

--- a/test/sidebar.test.js
+++ b/test/sidebar.test.js
@@ -1,0 +1,44 @@
+// Tests for Issue #37: close icon should use SVG x-circle instead of &times; entity
+// Tests read source files as text — correct for renderer modules that depend on DOM at module scope.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const sidebarSrc = fs.readFileSync(path.resolve(__dirname, '../renderer/sidebar.js'), 'utf8');
+const stylesSrc = fs.readFileSync(path.resolve(__dirname, '../styles.css'), 'utf8');
+
+describe('remove-btn', () => {
+  it('renders SVG not times entity', () => {
+    // The button template must use the SVG_X_CIRCLE constant, not &times;
+    assert.ok(
+      !sidebarSrc.includes('&times;'),
+      'sidebar.js must not use &times; entity for the remove button'
+    );
+    assert.ok(
+      sidebarSrc.includes('SVG_X_CIRCLE'),
+      'sidebar.js must define and use SVG_X_CIRCLE for the remove button'
+    );
+  });
+
+  it('SVG has circle and x lines', () => {
+    // Extract the SVG_X_CIRCLE constant value
+    const match = sidebarSrc.match(/SVG_X_CIRCLE\s*=\s*'([^']+)'/);
+    assert.ok(match, 'SVG_X_CIRCLE constant must be defined');
+    const svgSrc = match[1];
+    assert.ok(svgSrc.includes('<circle'), 'SVG_X_CIRCLE must contain a <circle element');
+    assert.ok(svgSrc.includes('<line'), 'SVG_X_CIRCLE must contain <line elements for the X');
+  });
+
+  it('CSS opacity at rest is 0.5', () => {
+    // Remove btn should be visible at rest, matching project-section-link
+    const removeBtnBlock = stylesSrc.match(/\.remove-btn\s*\{([^}]+)\}/);
+    assert.ok(removeBtnBlock, '.remove-btn CSS block must exist');
+    const block = removeBtnBlock[1];
+    assert.ok(
+      block.includes('opacity: 0.5'),
+      '.remove-btn must have opacity: 0.5 at rest (currently 0.15 — too dark)'
+    );
+  });
+});


### PR DESCRIPTION
Closes #37

## Summary

Replaces the plain `&times;` HTML entity on the remove-project button with a feather-style `x-circle` SVG (circle + two diagonal lines, 14×14 px, `stroke="currentColor"`), matching the style of the neighbouring TODO and GitHub icons. Updates `.remove-btn` CSS to raise resting opacity from `0.15` to `0.5` and base colour from `#555` to `#666`, aligning with `.project-section-link`. Also fixes the broken `npm test` script (`node --test test/` → `node --test`).

## Spec
[specs/spec-20260519-close-icon/spec.html](../blob/claude/issue-37/specs/spec-20260519-close-icon/spec.html)

## Test plan
- [x] `npm test` — 22 tests, 22 pass, 0 fail (includes 3 new assertions in `test/sidebar.test.js`)
  - `remove-btn renders SVG not times entity`
  - `remove-btn SVG has circle and x lines`
  - `CSS opacity at rest is 0.5`

## Routine notes
- Run: https://claude.ai/code/session_013pSFm4uzdW2naoiy2UWdZy
- Ready for review (all tasks done, all verify commands exit 0, no uncertain assumptions, no open questions)

---
_Generated by [Claude Code](https://claude.ai/code/session_013pSFm4uzdW2naoiy2UWdZy)_