### PR TITLE
[routine] ability to create github repo in braska directly

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,6 +451,37 @@
     </div>
   </div>
 
+  <!-- Publish to GitHub modal -->
+  <div id="publish-modal">
+    <div class="clone-modal-content">
+      <h3>Publish to GitHub</h3>
+      <div class="wt-form-group">
+        <label>Repository name</label>
+        <input type="text" id="publish-repo-name" placeholder="my-project" spellcheck="false">
+      </div>
+      <div class="wt-form-group">
+        <label>Account</label>
+        <select id="publish-account-select"><option value="">Loading…</option></select>
+      </div>
+      <div class="wt-form-group">
+        <label>Visibility</label>
+        <div class="publish-visibility-row">
+          <label><input type="radio" name="publish-visibility" value="private" checked> Private</label>
+          <label><input type="radio" name="publish-visibility" value="public"> Public</label>
+        </div>
+      </div>
+      <div class="wt-form-group">
+        <label>Description <span class="publish-optional">(optional)</span></label>
+        <input type="text" id="publish-description" placeholder="Short description of your project" spellcheck="false">
+      </div>
+      <div class="wt-error" id="publish-error"></div>
+      <div class="wt-modal-buttons">
+        <button id="publish-cancel">Cancel</button>
+        <button id="publish-submit" disabled>Publish</button>
+      </div>
+    </div>
+  </div>
+
   <script type="module" src="renderer/app.js"></script>
 </body>
 </html>

--- a/main/git-read.js
+++ b/main/git-read.js
@@ -132,7 +132,13 @@ function register({ ipcMain }) {
         } catch {}
       } catch { /* non-critical */ }
 
-      return { isGit: true, branch, unstaged, staged, untracked, conflicted, mainDivergence, mainStale };
+      let hasRemote = false;
+      try {
+        const { stdout: remoteOut } = await execFileAsync('git', ['remote'], opts);
+        hasRemote = remoteOut.trim().length > 0;
+      } catch {}
+
+      return { isGit: true, branch, unstaged, staged, untracked, conflicted, mainDivergence, mainStale, hasRemote };
     } catch {
       return { isGit: false, unstaged: [], staged: [], untracked: [] };
     }

--- a/main/github.js
+++ b/main/github.js
@@ -262,6 +262,53 @@ function register({ ipcMain }) {
     } catch (err) { return { ok: false, error: err.stderr || err.message }; }
   });
 
+  ipcMain.handle('gh:repo-create', async (_event, workDir, name, owner, isPrivate, description) => {
+    try {
+      const opts = { cwd: workDir, encoding: 'utf-8', timeout: 60000 };
+      // Check for commits; skip --push if the repo is empty (nothing to push yet).
+      let hasCommits = false;
+      try {
+        await execFileAsync('git', ['rev-parse', 'HEAD'], opts);
+        hasCommits = true;
+      } catch {}
+
+      const repoRef = `${owner}/${name}`;
+      const args = ['repo', 'create', repoRef, isPrivate ? '--private' : '--public',
+        '--source', workDir, '--remote', 'origin'];
+      if (description) args.push('--description', description);
+      if (hasCommits) args.push('--push');
+
+      const { stdout } = await execFileAsync('gh', args, opts);
+      return { ok: true, url: stdout.trim(), noCommits: !hasCommits };
+    } catch (err) {
+      if (isAuthError(err)) return { ok: false, error: errMsg(err), needsAuth: true };
+      return { ok: false, error: errMsg(err) };
+    }
+  });
+
+  ipcMain.handle('gh:list-accounts', async () => {
+    try {
+      const [userRes, orgsRes] = await Promise.allSettled([
+        execFileAsync('gh', ['api', '/user'], { encoding: 'utf-8', timeout: 15000 }),
+        execFileAsync('gh', ['api', '/user/orgs?per_page=100'], { encoding: 'utf-8', timeout: 15000 }),
+      ]);
+      if (userRes.status === 'rejected') {
+        if (isAuthError(userRes.reason)) return { ok: false, error: errMsg(userRes.reason), needsAuth: true };
+        return { ok: false, error: errMsg(userRes.reason) };
+      }
+      const user = JSON.parse(userRes.value.stdout);
+      const accounts = [{ login: user.login, type: 'user' }];
+      if (orgsRes.status === 'fulfilled') {
+        const orgs = JSON.parse(orgsRes.value.stdout);
+        for (const org of orgs) accounts.push({ login: org.login, type: 'org' });
+      }
+      return { ok: true, accounts };
+    } catch (err) {
+      if (isAuthError(err)) return { ok: false, error: errMsg(err), needsAuth: true };
+      return { ok: false, error: errMsg(err) };
+    }
+  });
+
   ipcMain.handle('gh:issue-labels', async (_event, workDir) => {
     try {
       const { stdout } = await execFileAsync('gh', ['label', 'list', '--json', 'name,color', '--limit', '100'], { cwd: workDir, encoding: 'utf-8', timeout: 15000 });

--- a/preload.js
+++ b/preload.js
@@ -137,6 +137,8 @@ contextBridge.exposeInMainWorld('github', {
   notificationsMarkRead: (workDir) => ipcRenderer.invoke('gh:notifications-mark-read', workDir),
   linkTicket: (workDir, todoPath, issueNumber) => ipcRenderer.invoke('gh:link-ticket', workDir, todoPath, issueNumber),
   unlinkTicket: (workDir, todoPath) => ipcRenderer.invoke('gh:unlink-ticket', workDir, todoPath),
+  repoCreate: (workDir, name, owner, isPrivate, description) => ipcRenderer.invoke('gh:repo-create', workDir, name, owner, isPrivate, description),
+  listAccounts: () => ipcRenderer.invoke('gh:list-accounts'),
 });
 
 // PTY bridge — thin IPC layer, multi-tab support

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -17,6 +17,7 @@ import { initGitHubPRs, showGitHubPRDetail } from './github-prs.js';
 import { refreshTodos, showTodoClosePrompt, updateTodoFocus, initTodoPanel } from './todo-panel.js';
 import { initHoverLink } from './hover-link.js';
 import { initCloneModal } from './clone-modal.js';
+import { openPublishModal, initPublishModal } from './publish-modal.js';
 import { initDiagnosticsPanel } from './diagnostics-panel.js';
 
 // ── Prevent Electron from navigating to dropped files ──
@@ -265,15 +266,16 @@ initTabs({ showTabTypePicker, updateFileTreeHighlights, showTodoClosePrompt, ref
 initTerminals({ refreshRightPanel });
 initNotifications({ openWorkDir, switchTab, exitSettings });
 initFileExplorer({ openFileEditor, openDiffTab, refreshChanges, startTask, startBrowser, switchTab, refreshTodos, refreshGitHub });
-initGitChanges({ refreshFileTree, startTask, loadProjects, switchTab, addTabToOrder, renderTabBar, tabsForWorkDir });
+initGitChanges({ refreshFileTree, startTask, loadProjects, switchTab, addTabToOrder, renderTabBar, tabsForWorkDir, openPublishModal });
 initPostCommitPromptBridge();
 initGitHubViewBridge({ refreshGitHub, switchRightPanelTab });
-initJourneyZone({ doPush, doPullLatestMain, openBranchModal, refreshChanges, showChangesStatus, startTask, refreshWorktreeMetrics, loadProjects, openWorkDir, switchToGitHubView, showGitHubPRDetail });
+initJourneyZone({ doPush, doPullLatestMain, openBranchModal, refreshChanges, showChangesStatus, startTask, refreshWorktreeMetrics, loadProjects, openWorkDir, switchToGitHubView, showGitHubPRDetail, openPublishModal });
 initGitHubPanel({ startTask, switchRightPanelTab, loadProjects, openWorkDir });
 initGitHubPRs({ loadProjects, openWorkDir, closeTab, tabsForWorkDir });
 initTodoPanel({ loadProjects, openWorkDir, startTask, showGitHubIssueDetail, switchRightPanelTab, switchToGitHubView });
 initHoverLink();
 initCloneModal({ loadProjects, openWorkDir });
+initPublishModal({ loadProjects, refreshChanges, getActiveWorkDir: () => tabState.activeWorkDir });
 initDiagnosticsPanel();
 
 // ── Tab type picker modal handlers ──

--- a/renderer/git-changes.js
+++ b/renderer/git-changes.js
@@ -13,11 +13,13 @@ import { renderJourneyZone, getCachedPRPillHtml } from './journey-zone.js';
 let _refreshFileTree = null;
 let _startTask = null;
 let _loadProjects = null;
+let _openPublishModal = null;
 
-export function initGitChanges({ refreshFileTree, startTask, loadProjects, switchTab, addTabToOrder, renderTabBar, tabsForWorkDir }) {
+export function initGitChanges({ refreshFileTree, startTask, loadProjects, switchTab, addTabToOrder, renderTabBar, tabsForWorkDir, openPublishModal }) {
   _refreshFileTree = refreshFileTree;
   _startTask = startTask;
   _loadProjects = loadProjects;
+  _openPublishModal = openPublishModal || null;
 
   // Forward deps to modals sub-module
   initChangesModals({
@@ -302,6 +304,7 @@ async function _refreshChangesInner(workDir) {
       if (result.ok) {
         if (_loadProjects) _loadProjects();
         refreshChanges(workDir);
+        if (_openPublishModal) _openPublishModal(workDir);
       } else {
         btn.disabled = false;
         btn.textContent = 'Initialize Repository';

--- a/renderer/journey-cards.mjs
+++ b/renderer/journey-cards.mjs
@@ -86,6 +86,17 @@ export function computeJourneyCards(status, opts = {}) {
     });
   }
 
+  // ── Priority 4c: No remote configured — offer GitHub publish ──
+  if (status?.hasRemote === false) {
+    cards.push({
+      key: 'publish-github', accent: 'ready',
+      title: 'Publish to GitHub',
+      tooltip: 'Create a GitHub repository and push your work',
+      buttons: [{ label: 'Publish to GitHub', action: 'publish-to-github', primary: true }],
+    });
+    return cards;
+  }
+
   // ── Priority 5: Ready to share ──
   if (div?.pushAhead > 0 && div.hasUpstream) {
     const btns = [{ label: 'Push', action: 'push', primary: true }];

--- a/renderer/journey-zone.js
+++ b/renderer/journey-zone.js
@@ -19,6 +19,7 @@ let _loadProjects = null;
 let _openWorkDir = null;
 let _switchToGitHubView = null;
 let _showGitHubPRDetail = null;
+let _openPublishModal = null;
 
 // ── PR-for-branch cache ────────────────────────────────────────
 // Keyed by `${workDir}::${branch}`. Value: { pr: { number, url } | null, ts }.
@@ -76,6 +77,7 @@ export function initJourneyZone(deps) {
   _openWorkDir = deps.openWorkDir;
   _switchToGitHubView = deps.switchToGitHubView;
   _showGitHubPRDetail = deps.showGitHubPRDetail;
+  _openPublishModal = deps.openPublishModal || null;
 
   // Delegated click for the PR pill rendered inside #branch-subtitle
   document.getElementById('branch-subtitle')?.addEventListener('click', (e) => {
@@ -336,6 +338,9 @@ async function _handleJourneyAction(action, btn) {
     _startTask?.('merger', workDir, {
       initialPrompt: 'Resolve all merge conflicts in this repository. Check git status, open conflicting files, resolve the conflicts, stage, and commit.',
     });
+
+  } else if (action === 'publish-to-github') {
+    _openPublishModal?.(workDir);
   }
 }
 

--- a/renderer/publish-modal.js
+++ b/renderer/publish-modal.js
@@ -1,0 +1,139 @@
+// Publish to GitHub modal — collects name, account, visibility, description,
+// then calls gh:repo-create to create the remote repo and set origin.
+
+import { modalState } from './state.js';
+import { escHtml } from './utils.js';
+
+const modal = document.getElementById('publish-modal');
+const nameInput = document.getElementById('publish-repo-name');
+const accountSelect = document.getElementById('publish-account-select');
+const descriptionInput = document.getElementById('publish-description');
+const errorEl = document.getElementById('publish-error');
+const submitBtn = document.getElementById('publish-submit');
+
+let _loadProjects = null;
+let _refreshChanges = null;
+let _getActiveWorkDir = null;
+let _activeWorkDir = null;
+let _accountsLoaded = false;
+
+function getVisibility() {
+  return document.querySelector('input[name="publish-visibility"]:checked')?.value === 'public';
+}
+
+function setError(msg) {
+  if (msg) { errorEl.textContent = msg; errorEl.classList.add('visible'); }
+  else { errorEl.textContent = ''; errorEl.classList.remove('visible'); }
+}
+
+function updateSubmitBtn() {
+  submitBtn.disabled = modalState.publishBusy ||
+    !nameInput.value.trim() ||
+    !accountSelect.value;
+}
+
+async function loadAccounts() {
+  accountSelect.innerHTML = '<option value="">Loading…</option>';
+  accountSelect.disabled = true;
+  const result = await window.github.listAccounts();
+  if (!result.ok) {
+    const hint = result.needsAuth
+      ? 'Run `gh auth login` in a terminal, then try again.'
+      : (result.error || 'Failed to load accounts.');
+    accountSelect.innerHTML = `<option value="">${escHtml(hint)}</option>`;
+    return;
+  }
+  _accountsLoaded = true;
+  accountSelect.innerHTML = result.accounts
+    .map(a => `<option value="${escHtml(a.login)}">${escHtml(a.login)}${a.type === 'org' ? ' (org)' : ''}</option>`)
+    .join('');
+  accountSelect.disabled = false;
+  updateSubmitBtn();
+}
+
+export function openPublishModal(workDir) {
+  _activeWorkDir = workDir || (_getActiveWorkDir ? _getActiveWorkDir() : null);
+  if (!_activeWorkDir) return;
+
+  // Pre-fill name from the folder basename.
+  const folderName = _activeWorkDir.split('/').filter(Boolean).pop() || '';
+  nameInput.value = folderName;
+  descriptionInput.value = '';
+  document.querySelector('input[name="publish-visibility"][value="private"]').checked = true;
+  setError('');
+  modalState.publishBusy = false;
+  submitBtn.textContent = 'Publish';
+
+  _accountsLoaded = false;
+  loadAccounts();
+  updateSubmitBtn();
+
+  modal.classList.add('active');
+  nameInput.focus();
+  nameInput.select();
+}
+
+function closeModal() {
+  modal.classList.remove('active');
+  _activeWorkDir = null;
+}
+
+async function doPublish() {
+  if (modalState.publishBusy) return;
+  const name = nameInput.value.trim();
+  const owner = accountSelect.value;
+  if (!name || !owner) return;
+
+  const isPrivate = !getVisibility();
+  const description = descriptionInput.value.trim();
+
+  modalState.publishBusy = true;
+  submitBtn.disabled = true;
+  submitBtn.textContent = 'Publishing…';
+  setError('');
+
+  const result = await window.github.repoCreate(_activeWorkDir, name, owner, isPrivate, description);
+
+  modalState.publishBusy = false;
+  submitBtn.textContent = 'Publish';
+
+  if (!result.ok) {
+    submitBtn.disabled = false;
+    const hint = result.needsAuth
+      ? ' Run `gh auth login` in a terminal and try again.'
+      : '';
+    setError((result.error || 'Failed to create repository.') + hint);
+    return;
+  }
+
+  closeModal();
+  await _loadProjects?.();
+  if (_activeWorkDir && _refreshChanges) _refreshChanges(_activeWorkDir);
+
+  if (result.noCommits) {
+    // Repo was created but nothing was pushed — surface an informational message
+    // via a brief status in the changes panel. We don't have a direct status
+    // fn reference here, so use a native alert (low-frequency path).
+    alert(`Repository created at ${result.url}\n\nNo commits to push yet — make your first commit and then push.`);
+  }
+}
+
+export function initPublishModal({ loadProjects, refreshChanges, getActiveWorkDir }) {
+  _loadProjects = loadProjects;
+  _refreshChanges = refreshChanges;
+  _getActiveWorkDir = getActiveWorkDir;
+
+  nameInput.addEventListener('input', updateSubmitBtn);
+  accountSelect.addEventListener('change', updateSubmitBtn);
+
+  nameInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !submitBtn.disabled) doPublish();
+  });
+
+  document.getElementById('publish-cancel').addEventListener('click', closeModal);
+  submitBtn.addEventListener('click', doPublish);
+
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal && !modalState.publishBusy) closeModal();
+  });
+}

--- a/renderer/state.js
+++ b/renderer/state.js
@@ -40,6 +40,7 @@ export const modalState = {
   cloneRepoRef: '',           // parsed/selected owner/repo
   cloneDestParent: '',        // chosen parent directory (absolute)
   cloneBusy: false,           // true while a clone is in-flight
+  publishBusy: false,         // true while a gh repo create is in-flight
 };
 
 // ── File explorer state ─────────────────────────────────────────

--- a/specs/spec-20260519-create-github-repo-in-braska/research.md
+++ b/specs/spec-20260519-create-github-repo-in-braska/research.md
@@ -1,0 +1,96 @@
+# Research — ability to create github repo in braska directly (#39)
+
+## 1. Problem Summary
+
+A user who starts a new local project, uses Braska's "Initialize Repository" button to run `git init`, then wants to publish that repo to GitHub — all without leaving the app. The feature needs to collect: which GitHub account/org to create under, the repo name, public vs private visibility, and a description. After creation it should wire up the `origin` remote and push the initial commit (if any).
+
+---
+
+## 2. Verified Codebase Facts
+
+**`gh:auth-status` return shape** (`main/github.js` lines 18–38):
+`{ authenticated, user, isGitHubRepo, repo }` — `isGitHubRepo` is set by running `gh repo view` in `cwd`. Requires a network call. Already distinguishes "no GitHub remote" from "connected", but is a network call and runs cwd-relative.
+
+**`git:status` return shape** (`main/git-read.js` line 135):
+`{ isGit, branch, unstaged, staged, untracked, conflicted, mainDivergence, mainStale }` — no `hasRemote` or `isGitHub` field. Called on every panel refresh (hot path).
+
+**Remote detection already exists in 3 places:**
+- `main/projects.js` `getGitInfo()` — `git remote get-url origin`, sets `isGitHub` (sidebar/projects list).
+- `main/git-worktree.js` `git:is-github-repo` handler — same pattern, exposed via `window.worktree.isGitHubRepo(workDir)`.
+- `main/git-worktree.js` `git:pull-latest-main` — one-off check inside a mutation handler.
+
+**"Initialize Repository" flow** (`renderer/git-changes.js` lines 285–311): When `status.isGit === false`, panel renders `<div class="changes-not-git">` with an "Initialize Repository" button. After `window.gitOps.init(workDir)` succeeds, calls `refreshChanges(workDir)` and `_loadProjects()`. Natural insertion point for "Publish to GitHub" as the next step.
+
+**`gh repo create` CLI**: `gh repo create <name> --public|--private [--description "..."] [--source . --push]` handles the full workflow in one command.
+
+**Account/org enumeration**: `gh api /user` (personal user) and `gh api /user/orgs` (orgs the user belongs to) together give the full list of owners.
+
+**`clone-modal.js`** is the best reference implementation: two-tab modal, list loading, error states, calls `window.github.*` IPC then `window.projects.addCloned()`.
+
+---
+
+## 3. Four Plausible Approaches
+
+**Approach A — Post-init prompt in `git-changes.js`**
+After `git:init` succeeds, immediately open a modal offering "Publish to GitHub". Trigger is at the exact moment the user created a local repo.
+- **Pro:** Zero friction — user is already looking at the changes panel.
+- **Con:** Inline state complexity in `git-changes.js`; the panel doesn't own modal state today.
+
+**Approach B — Journey zone card for "local git, no remote"**
+Add a card in `journey-cards.mjs` firing when `isGit && !hasRemote`. Requires adding `hasRemote` to `git:status`.
+- **Pro:** Journey zone is the canonical home for "what to do next" guidance.
+- **Con:** Adds a `git remote` syscall to the hot path (though cheap — reads `.git/config`, no network).
+
+**Approach C — Lazy check via `worktree.isGitHubRepo` + journey card**
+Keep `git:status` clean; fire a one-time lazy call to `window.worktree.isGitHubRepo(workDir)` and cache in `gitState`.
+- **Pro:** No hot-path overhead.
+- **Con:** Async complexity — a second refresh or a `gitState` flag triggers re-render; journey zone currently computes cards synchronously from `status` alone.
+
+**Approach D — "Publish" button in non-git / post-init state only**
+Show "Publish to GitHub" only inside the `changes-not-git` block as a second button shown after init.
+- **Pro:** Simplest scope; no changes to `git:status`, journey zone, or detection.
+- **Con:** Misses existing local-only repos with no remote; discoverability is poor.
+
+---
+
+## 4. Industry Precedent
+
+**VS Code:** When a git repo has no `origin` remote, shows "Publish Branch" in the Source Control header. Triggers GitHub extension flow: enumerates user + orgs via GitHub API, presents quick-pick, asks public/private, creates via REST API, adds remote, pushes. Repo name defaults to folder basename.
+
+**GitHub Desktop:** Shows "Publish repository" button in toolbar whenever the current repo has no remote. Modal with: name (pre-filled), description, "Keep this code private" checkbox, organization dropdown. Calls GitHub REST API directly.
+
+**IntelliJ IDEA:** VCS → Share Project on GitHub. Dialog with remote name, GitHub account selector, repo name, description, private checkbox.
+
+**Common pattern:** (1) default name = folder basename, (2) account selector = personal + orgs, (3) visibility default = private, (4) optional description, (5) auto-add remote + push after creation.
+
+---
+
+## 5. Recommended Approach
+
+**Combine Approach A and B** — a `PublishModal` triggered from two entry points.
+
+**Entry point 1 (post-init):** After `git:init` succeeds in `git-changes.js`, automatically open the modal pre-filled with the folder basename. Highest-signal moment, zero extra detection needed.
+
+**Entry point 2 (existing local repos):** In `journey-cards.mjs`, add a `publish-to-github` card when `status.hasRemote === false`. Detect `hasRemote` by adding a single `git remote` call inside `git:status` — this is a pure local read (reads `.git/config`, no network), cheap, consistent with other divergence info computed there.
+
+**New IPC `gh:repo-create`** in `main/github.js` using `gh repo create <owner>/<name> --public|--private [--description "..."] --source <workDir> --remote origin --push`.
+
+**New IPC `gh:list-accounts`** that calls `gh api /user` + `gh api /user/orgs?per_page=100` and returns `[{ login, type: 'user'|'org' }]`.
+
+**New modal** `renderer/publish-modal.js` (modelled on `clone-modal.js`): repo name, owner picker, visibility radio (private default), optional description.
+
+**Preload additions**: `window.github.repoCreate(workDir, name, owner, isPrivate, description)` and `window.github.listAccounts()`.
+
+---
+
+## 6. Unknowns
+
+1. **No-commits edge case:** If the local repo has no commits yet, `gh repo create --source . --push` will fail (nothing to push). Need to detect via `git rev-parse HEAD` and skip `--push` or warn the user.
+
+2. **`gh repo create` org syntax:** Whether to use `<org>/<name>` as positional arg vs `--org <org>` flag. Verify with `gh repo create --help` at runtime.
+
+3. **`gh api /user/orgs` pagination:** Default returns 30; need `per_page=100` consistent with `gh:list-repos`.
+
+4. **SSH vs HTTPS remote URL:** `gh repo create --source . --push` sets the remote using whatever protocol `gh` is configured for. A push failure after creation (credentials mismatch) should surface the remote URL so the user can push manually.
+
+5. **Modal placement in `index.html`:** A new `<div id="publish-modal">` must be added.

--- a/specs/spec-20260519-create-github-repo-in-braska/spec.html
+++ b/specs/spec-20260519-create-github-repo-in-braska/spec.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Spec — ability to create github repo in braska directly (#39)</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 80ch; margin: 2rem auto; padding: 0 1rem; color: #222; line-height: 1.5; }
+  h1, h2 { border-bottom: 1px solid #ddd; padding-bottom: .25rem; }
+  .meta { color: #777; font-size: .9rem; }
+  .status { font-weight: 600; color: #0d47a1; margin: 0 0 1.5rem; padding: .5rem .9rem; background: #e3f2fd; border-left: 3px solid #1565c0; border-radius: 3px; }
+  blockquote { border-left: 3px solid #888; padding: .25rem .9rem; color: #444; background: #fafafa; }
+  ul.check { list-style: none; padding-left: .5rem; }
+  ul.check ul { padding-left: 1.5rem; margin: .1rem 0; }
+  ul.check li.done { color: #888; text-decoration: line-through; }
+  ul.check li.active { font-weight: bold; }
+  ul.check li.deferred { color: #888; }
+  ul.check li::before { content: "☐ "; }
+  ul.check li.done::before { content: "☑ "; color: #2e7d32; text-decoration: none; }
+  ul.check li.active::before { content: "▶ "; color: #1565c0; }
+  ul.check li.deferred::before { content: "⏸ "; color: #f57c00; text-decoration: none; }
+  .story { display: block; font-style: italic; color: #555; font-size: .9rem; padding-left: 1.5rem; }
+  .testref { display: block; font-family: ui-monospace, "SF Mono", monospace; color: #2e7d32; font-size: .85rem; padding-left: 1.5rem; }
+  .entry { border-left: 2px solid #ccc; padding: .25rem .9rem; margin: .5rem 0; }
+  .entry time { color: #999; font-size: .85rem; display: block; }
+  .entry.dont { border-left-color: #c62828; }
+  .entry.dont strong { color: #c62828; }
+  .assume { padding: .1rem 0; }
+  .assume.uncertain { color: #c62828; }
+  .assume.uncertain::before { content: "⚠ "; }
+  .assume.confident::before { content: "• "; }
+  pre.cmd { background: #f3f3f3; padding: .35rem .6rem; margin: .15rem 0; border-radius: 3px; font-size: .9rem; overflow-x: auto; }
+  code { background: #f3f3f3; padding: 0 .2rem; border-radius: 3px; }
+</style>
+</head>
+<body>
+<h1>ability to create github repo in braska directly</h1>
+<p class="meta">Issue <a href="https://github.com/derek-hobden/braska/issues/39">#39</a> · branch <code>claude/sharp-gauss-LJLGz</code> · started 2026-05-19T00:00:00Z</p>
+<p class="status">Spec drafted; implementation not started.</p>
+
+<h2>Issue body</h2>
+<blockquote>it would be cool if after I start a new project on my laptop, and use the button in braska to init a git repo, I could then turn the repo into a GitHub repo from inside brisk too. it should ask which account I want to create it on, what the name of the repo should be, if it should be public or private, and anything else you can think of that makes sense.</blockquote>
+
+<h2>Chosen approach</h2>
+<p>Two entry points feed one "Publish to GitHub" modal (<code>renderer/publish-modal.js</code>). Entry point 1: after <code>git:init</code> succeeds in <code>git-changes.js</code>, immediately open the modal — the highest-signal moment, no detection work needed. Entry point 2: add <code>hasRemote</code> to the <code>git:status</code> response (a pure local read of <code>.git/config</code> via <code>git remote</code>, no network), then render a "Publish to GitHub" journey card whenever a git repo has no remote. The modal collects: repo name (pre-filled from folder basename), owner (personal account + orgs via new <code>gh:list-accounts</code> handler), visibility (private by default), and optional description. On submit, <code>gh:repo-create</code> calls <code>gh repo create &lt;owner&gt;/&lt;name&gt; --source . --remote origin [--push]</code>, skipping push if the repo has no commits yet. This mirrors VS Code's "Publish Branch" and GitHub Desktop's "Publish repository" patterns.</p>
+
+<h2>Assumptions</h2>
+<ul>
+  <li class="assume confident">The installed <code>gh</code> CLI supports <code>gh repo create &lt;owner/name&gt; --source &lt;path&gt; --remote origin --push</code> (available since gh v2.4).</li>
+  <li class="assume confident">Org repos are created using <code>&lt;org&gt;/&lt;name&gt;</code> as the positional argument to <code>gh repo create</code> (not <code>--org</code> flag).</li>
+  <li class="assume confident"><code>gh api /user/orgs?per_page=100</code> returns all orgs the authenticated user belongs to (same pattern as <code>gh:list-repos</code>).</li>
+  <li class="assume confident">Adding a single <code>git remote</code> call to <code>git:status</code> is acceptable latency — it reads <code>.git/config</code> locally, no network, same order as other status checks already done there.</li>
+  <li class="assume uncertain">If the user has no commits yet, <code>gh repo create --source . --push</code> fails. We assume detecting this via <code>git rev-parse HEAD</code> and omitting <code>--push</code> is the right fallback (create the remote but let the user push manually). Human should verify this is the desired UX.</li>
+  <li class="assume uncertain">Default visibility should be <code>private</code> (matching GitHub Desktop). Human should confirm this matches the product expectation.</li>
+</ul>
+
+<h2>Definition of done</h2>
+<ul>
+  <li>Clicking "Initialize Repository" in the Changes panel and then submitting the Publish modal creates a new GitHub repo and sets <code>origin</code> remote in the local git config.</li>
+  <li>The sidebar immediately shows the repo as a GitHub project (GitHub icon / badge) after publish succeeds.</li>
+  <li>A "Publish to GitHub" journey card appears on any git repo that has no remote configured (i.e., not just freshly-inited ones).</li>
+  <li>The modal pre-fills repo name from the folder basename.</li>
+  <li>The account dropdown lists the authenticated user's personal login plus all orgs they belong to.</li>
+  <li>Visibility defaults to private; user can toggle to public.</li>
+  <li>Description field is optional.</li>
+  <li>If the repo has no commits, publish succeeds without a push and the user sees an informational message.</li>
+  <li>Auth errors surface a message pointing to <code>gh auth login</code>.</li>
+  <li><code>node --test</code> passes with new tests for <code>gh:repo-create</code> and <code>gh:list-accounts</code>.</li>
+</ul>
+
+<h2>Up-front tests</h2>
+<ul>
+  <li><code>test/gh-repo-create.test.js::creates repo and pushes when commits exist</code> — asserts gh repo create is called with correct args including --push</li>
+  <li><code>test/gh-repo-create.test.js::creates repo without push when no commits</code> — asserts --push is omitted when git rev-parse HEAD fails</li>
+  <li><code>test/gh-repo-create.test.js::propagates auth error</code> — asserts needsAuth:true when gh exits with auth error text</li>
+  <li><code>test/gh-repo-create.test.js::list-accounts returns user plus orgs</code> — asserts gh:list-accounts combines /user and /user/orgs responses</li>
+  <li><code>test/git-status-has-remote.test.js::hasRemote false when no remotes</code> — asserts git:status returns hasRemote:false when git remote returns empty</li>
+  <li><code>test/git-status-has-remote.test.js::hasRemote true when origin exists</code> — asserts git:status returns hasRemote:true when git remote returns origin</li>
+</ul>
+
+<h2>Tasks</h2>
+<ul class="check">
+  <li class="active">Write up-front tests for <code>gh:repo-create</code>, <code>gh:list-accounts</code>, and <code>hasRemote</code> in <code>git:status</code>; confirm they fail before implementation
+    <span class="story">Story: As a developer, when I run the test suite before implementation, then these new tests should fail with "No handler registered" or assertion errors.</span>
+    <span class="testref">test: test/gh-repo-create.test.js, test/git-status-has-remote.test.js</span>
+  </li>
+  <li>Add <code>hasRemote</code> to <code>git:status</code> response in <code>main/git-read.js</code>
+    <span class="story">Story: As the journey zone, when I receive a git:status response, then I can read hasRemote to decide whether to show the Publish card.</span>
+    <span class="testref">test: test/git-status-has-remote.test.js</span>
+  </li>
+  <li>Add <code>gh:repo-create</code> and <code>gh:list-accounts</code> IPC handlers in <code>main/github.js</code>
+    <span class="story">Story: As the publish modal, when I call window.github.repoCreate and window.github.listAccounts, then I get the expected data back via IPC.</span>
+    <span class="testref">test: test/gh-repo-create.test.js</span>
+  </li>
+  <li>Expose <code>github.repoCreate</code> and <code>github.listAccounts</code> in <code>preload.js</code>
+    <span class="story">Story: As the renderer, when I call window.github.repoCreate(...) or window.github.listAccounts(), then the call reaches the main process.</span>
+  </li>
+  <li>Add <code>#publish-modal</code> HTML to <code>index.html</code>
+    <span class="story">Story: As the publish modal JS, when I query #publish-modal, then the DOM element exists with the expected form fields.</span>
+  </li>
+  <li>Implement <code>renderer/publish-modal.js</code> — modal open/submit/close logic
+    <span class="story">Story: As a user, when I open the Publish modal, then I see my repo name pre-filled, a dropdown of my accounts/orgs, visibility toggle, and description field.</span>
+  </li>
+  <li>Wire Entry Point 1: after <code>git:init</code> succeeds in <code>renderer/git-changes.js</code>, open the publish modal
+    <span class="story">Story: As a user, when I click "Initialize Repository" and init succeeds, then the Publish to GitHub modal opens immediately.</span>
+  </li>
+  <li>Add <code>publish-to-github</code> journey card to <code>renderer/journey-cards.mjs</code> (Entry Point 2)
+    <span class="story">Story: As a user, when I open a local git repo with no remote in the Changes panel, then I see a "Publish to GitHub" journey card.</span>
+  </li>
+  <li>Wire journey card action <code>publish-to-github</code> in <code>renderer/journey-zone.js</code> to open the publish modal
+    <span class="story">Story: As a user, when I click the "Publish to GitHub" card button, then the publish modal opens.</span>
+  </li>
+  <li>Init <code>publish-modal</code> in <code>renderer/app.js</code>
+    <span class="story">Story: As the app, when it starts, then the publish modal is initialized with its cross-module deps (loadProjects, refreshChanges, activeWorkDir accessor).</span>
+  </li>
+</ul>
+
+<h2>Verify</h2>
+<pre class="cmd">node --test test/gh-repo-create.test.js</pre>
+<pre class="cmd">node --test test/git-status-has-remote.test.js</pre>
+<pre class="cmd">node --test</pre>
+
+<h2>Decisions</h2>
+<!-- append entries in ascending chronological order -->
+
+<h2>Don'ts / rejected approaches</h2>
+
+<h2>Course corrections</h2>
+
+<h2>Subagent notes</h2>
+
+<h2>Follow-ups (deferred work)</h2>
+<ul>
+</ul>
+
+<h2>Open questions</h2>
+<ul>
+  <li>Should the default visibility be private (matching GitHub Desktop) or public? Spec assumes private — confirm with product owner before merge.</li>
+  <li>When there are no commits and push is skipped, should the modal show a success message explaining the user must push manually, or should it prompt them to make a first commit immediately?</li>
+</ul>
+
+<h2>Verification results</h2>
+<!-- populated by Phase 4; one block per Verify command with exit code and tail of output -->
+
+</body>
+</html>

--- a/specs/spec-20260519-create-github-repo-in-braska/spec.html
+++ b/specs/spec-20260519-create-github-repo-in-braska/spec.html
@@ -79,7 +79,7 @@
 
 <h2>Tasks</h2>
 <ul class="check">
-  <li class="active">Write up-front tests for <code>gh:repo-create</code>, <code>gh:list-accounts</code>, and <code>hasRemote</code> in <code>git:status</code>; confirm they fail before implementation
+  <li class="active">Write up-front tests (marking active) for <code>gh:repo-create</code>, <code>gh:list-accounts</code>, and <code>hasRemote</code> in <code>git:status</code>; confirm they fail before implementation
     <span class="story">Story: As a developer, when I run the test suite before implementation, then these new tests should fail with "No handler registered" or assertion errors.</span>
     <span class="testref">test: test/gh-repo-create.test.js, test/git-status-has-remote.test.js</span>
   </li>

--- a/specs/spec-20260519-create-github-repo-in-braska/spec.html
+++ b/specs/spec-20260519-create-github-repo-in-braska/spec.html
@@ -35,7 +35,7 @@
 <body>
 <h1>ability to create github repo in braska directly</h1>
 <p class="meta">Issue <a href="https://github.com/derek-hobden/braska/issues/39">#39</a> · branch <code>claude/sharp-gauss-LJLGz</code> · started 2026-05-19T00:00:00Z</p>
-<p class="status">Spec drafted; implementation not started.</p>
+<p class="status">Implementation complete; all tasks done.</p>
 
 <h2>Issue body</h2>
 <blockquote>it would be cool if after I start a new project on my laptop, and use the button in braska to init a git repo, I could then turn the repo into a GitHub repo from inside brisk too. it should ask which account I want to create it on, what the name of the repo should be, if it should be public or private, and anything else you can think of that makes sense.</blockquote>
@@ -79,37 +79,37 @@
 
 <h2>Tasks</h2>
 <ul class="check">
-  <li class="active">Write up-front tests (marking active) for <code>gh:repo-create</code>, <code>gh:list-accounts</code>, and <code>hasRemote</code> in <code>git:status</code>; confirm they fail before implementation
+  <li class="done">Write up-front tests for <code>gh:repo-create</code>, <code>gh:list-accounts</code>, and <code>hasRemote</code> in <code>git:status</code>; confirm they fail before implementation
     <span class="story">Story: As a developer, when I run the test suite before implementation, then these new tests should fail with "No handler registered" or assertion errors.</span>
     <span class="testref">test: test/gh-repo-create.test.js, test/git-status-has-remote.test.js</span>
   </li>
-  <li>Add <code>hasRemote</code> to <code>git:status</code> response in <code>main/git-read.js</code>
+  <li class="done">Add <code>hasRemote</code> to <code>git:status</code> response in <code>main/git-read.js</code>
     <span class="story">Story: As the journey zone, when I receive a git:status response, then I can read hasRemote to decide whether to show the Publish card.</span>
     <span class="testref">test: test/git-status-has-remote.test.js</span>
   </li>
-  <li>Add <code>gh:repo-create</code> and <code>gh:list-accounts</code> IPC handlers in <code>main/github.js</code>
+  <li class="done">Add <code>gh:repo-create</code> and <code>gh:list-accounts</code> IPC handlers in <code>main/github.js</code>
     <span class="story">Story: As the publish modal, when I call window.github.repoCreate and window.github.listAccounts, then I get the expected data back via IPC.</span>
     <span class="testref">test: test/gh-repo-create.test.js</span>
   </li>
-  <li>Expose <code>github.repoCreate</code> and <code>github.listAccounts</code> in <code>preload.js</code>
+  <li class="done">Expose <code>github.repoCreate</code> and <code>github.listAccounts</code> in <code>preload.js</code>
     <span class="story">Story: As the renderer, when I call window.github.repoCreate(...) or window.github.listAccounts(), then the call reaches the main process.</span>
   </li>
-  <li>Add <code>#publish-modal</code> HTML to <code>index.html</code>
+  <li class="done">Add <code>#publish-modal</code> HTML to <code>index.html</code>
     <span class="story">Story: As the publish modal JS, when I query #publish-modal, then the DOM element exists with the expected form fields.</span>
   </li>
-  <li>Implement <code>renderer/publish-modal.js</code> — modal open/submit/close logic
+  <li class="done">Implement <code>renderer/publish-modal.js</code> — modal open/submit/close logic
     <span class="story">Story: As a user, when I open the Publish modal, then I see my repo name pre-filled, a dropdown of my accounts/orgs, visibility toggle, and description field.</span>
   </li>
-  <li>Wire Entry Point 1: after <code>git:init</code> succeeds in <code>renderer/git-changes.js</code>, open the publish modal
+  <li class="done">Wire Entry Point 1: after <code>git:init</code> succeeds in <code>renderer/git-changes.js</code>, open the publish modal
     <span class="story">Story: As a user, when I click "Initialize Repository" and init succeeds, then the Publish to GitHub modal opens immediately.</span>
   </li>
-  <li>Add <code>publish-to-github</code> journey card to <code>renderer/journey-cards.mjs</code> (Entry Point 2)
+  <li class="done">Add <code>publish-to-github</code> journey card to <code>renderer/journey-cards.mjs</code> (Entry Point 2)
     <span class="story">Story: As a user, when I open a local git repo with no remote in the Changes panel, then I see a "Publish to GitHub" journey card.</span>
   </li>
-  <li>Wire journey card action <code>publish-to-github</code> in <code>renderer/journey-zone.js</code> to open the publish modal
+  <li class="done">Wire journey card action <code>publish-to-github</code> in <code>renderer/journey-zone.js</code> to open the publish modal
     <span class="story">Story: As a user, when I click the "Publish to GitHub" card button, then the publish modal opens.</span>
   </li>
-  <li>Init <code>publish-modal</code> in <code>renderer/app.js</code>
+  <li class="done">Init <code>publish-modal</code> in <code>renderer/app.js</code>
     <span class="story">Story: As the app, when it starts, then the publish modal is initialized with its cross-module deps (loadProjects, refreshChanges, activeWorkDir accessor).</span>
   </li>
 </ul>
@@ -120,7 +120,9 @@
 <pre class="cmd">node --test</pre>
 
 <h2>Decisions</h2>
-<!-- append entries in ascending chronological order -->
+<div class="entry"><time>2026-05-19</time>Used <code>&lt;owner&gt;/&lt;name&gt;</code> positional arg format for <code>gh repo create</code> rather than a <code>--org</code> flag — works for both personal accounts and orgs, consistent with how <code>gh</code> documents its API.</div>
+<div class="entry"><time>2026-05-19</time>Added <code>hasRemote</code> (bool) to <code>git:status</code> via a cheap <code>git remote</code> call (reads <code>.git/config</code>, no network) rather than <code>isGitHub</code> (which would require a <code>gh repo view</code> network call). The journey card fires on any no-remote repo, not just ones whose remote points to github.com.</div>
+<div class="entry"><time>2026-05-19</time>Used native <code>alert()</code> for the no-commits-after-publish case (low-frequency, non-blocking). If this proves janky, a <code>showChangesStatus</code> call would be cleaner but requires threading the dep into the modal.</div>
 
 <h2>Don'ts / rejected approaches</h2>
 
@@ -139,7 +141,7 @@
 </ul>
 
 <h2>Verification results</h2>
-<!-- populated by Phase 4; one block per Verify command with exit code and tail of output -->
+<p>See <a href="verify-results.md">verify-results.md</a>. All 3 commands exited 0. 32/32 tests pass.</p>
 
 </body>
 </html>

--- a/specs/spec-20260519-create-github-repo-in-braska/verify-results.md
+++ b/specs/spec-20260519-create-github-repo-in-braska/verify-results.md
@@ -1,0 +1,55 @@
+# Verify Results — ability to create github repo in braska directly (#39)
+
+## Command 1: `node --test test/gh-repo-create.test.js`
+
+**Exit code: 0**
+
+```
+# tests 9
+# suites 2
+# pass 9
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 122.052616
+```
+
+All 9 tests pass:
+- `gh:repo-create handler` (6 tests): creates repo and pushes when commits exist, creates without push when no commits, includes description, omits description when empty, propagates auth error, returns ok:false on general error.
+- `gh:list-accounts handler` (3 tests): returns user plus orgs, returns only user when orgs call fails, propagates auth error.
+
+## Command 2: `node --test test/git-status-has-remote.test.js`
+
+**Exit code: 0**
+
+```
+# tests 4
+# suites 1
+# pass 4
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 108.385162
+```
+
+All 4 tests pass:
+- `git:status hasRemote field` (4 tests): hasRemote false when no remotes, hasRemote true when origin exists, hasRemote true when any remote exists, hasRemote false on non-git directory.
+
+## Command 3: `node --test`
+
+**Exit code: 0**
+
+```
+# tests 32
+# suites 6
+# pass 32
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 256.134642
+```
+
+Full suite (all 32 tests across 6 suites) pass. No regressions.

--- a/styles.css
+++ b/styles.css
@@ -4039,6 +4039,47 @@
     #clone-cancel:hover { background: #2a2a2a; color: #ccc; }
 
 
+/* ── Publish to GitHub modal ── */
+    #publish-modal {
+      display: none;
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(0,0,0,0.6);
+      z-index: 150;
+      align-items: center;
+      justify-content: center;
+    }
+    #publish-modal.active { display: flex; }
+    .publish-visibility-row {
+      display: flex;
+      gap: 20px;
+    }
+    .publish-visibility-row label {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+      font-size: 0.85rem;
+      color: #ccc;
+    }
+    .publish-optional {
+      color: #666;
+      font-size: 0.8rem;
+      font-weight: normal;
+    }
+    #publish-submit {
+      background: #4a9eff;
+      border-color: #4a9eff;
+      color: #fff;
+    }
+    #publish-submit:hover:not(:disabled) { background: #3a8eef; }
+    #publish-submit:disabled { opacity: 0.5; cursor: not-allowed; }
+    #publish-cancel {
+      background: none;
+      color: #888;
+    }
+    #publish-cancel:hover { background: #2a2a2a; color: #ccc; }
+
 /* ── Diagnostics panel (Cmd+Shift+D) — gh issue #30 ── */
 #diagnostics-panel {
   position: fixed; top: 12px; right: 12px; z-index: 99999;

--- a/test/gh-repo-create.test.js
+++ b/test/gh-repo-create.test.js
@@ -1,0 +1,140 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { mockExec, installMocks, loadModule, mockIpcMain } = require('./helpers');
+
+describe('gh:repo-create handler', () => {
+  let exec, ipc;
+
+  beforeEach(() => {
+    exec = mockExec();
+    installMocks(exec);
+    const { register } = loadModule('../main/github');
+    ipc = mockIpcMain();
+    register({ ipcMain: ipc });
+  });
+
+  it('creates repo and pushes when commits exist', async () => {
+    exec.on('rev-parse HEAD', { stdout: 'abc123\n' });
+    exec.on('repo create', { stdout: 'https://github.com/alice/myrepo\n' });
+
+    const result = await ipc.invoke('gh:repo-create', '/project', 'myrepo', 'alice', true, 'My repo');
+
+    assert.ok(result.ok, `expected ok but got: ${result.error}`);
+    assert.ok(result.url.includes('github.com'), 'should return a GitHub URL');
+    const createCall = exec.calls.find(c => c.args.includes('create'));
+    assert.ok(createCall, 'should call gh repo create');
+    assert.ok(createCall.args.includes('alice/myrepo'), 'should use owner/name format');
+    assert.ok(createCall.args.includes('--private'), 'should set --private for isPrivate=true');
+    assert.ok(createCall.args.includes('--push'), 'should push when commits exist');
+    assert.ok(createCall.args.includes('--remote'), 'should set --remote');
+    assert.ok(createCall.args.includes('origin'), 'should use origin as remote name');
+  });
+
+  it('creates repo without push when no commits', async () => {
+    exec.on('rev-parse HEAD', { throws: 'fatal: ambiguous argument HEAD', stderr: 'fatal: ambiguous argument HEAD' });
+    exec.on('repo create', { stdout: 'https://github.com/alice/myrepo\n' });
+
+    const result = await ipc.invoke('gh:repo-create', '/project', 'myrepo', 'alice', false, '');
+
+    assert.ok(result.ok, `expected ok but got: ${result.error}`);
+    assert.ok(result.noCommits, 'should indicate no commits so user knows to push manually');
+    const createCall = exec.calls.find(c => c.args.includes('create'));
+    assert.ok(createCall, 'should call gh repo create');
+    assert.ok(!createCall.args.includes('--push'), 'should NOT push when no commits');
+    assert.ok(createCall.args.includes('--public'), 'should set --public for isPrivate=false');
+  });
+
+  it('includes description when provided', async () => {
+    exec.on('rev-parse HEAD', { stdout: 'abc\n' });
+    exec.on('repo create', { stdout: 'https://github.com/alice/myrepo\n' });
+
+    await ipc.invoke('gh:repo-create', '/project', 'myrepo', 'alice', true, 'A description');
+
+    const createCall = exec.calls.find(c => c.args.includes('create'));
+    const descIdx = createCall.args.indexOf('--description');
+    assert.ok(descIdx >= 0, 'should pass --description');
+    assert.equal(createCall.args[descIdx + 1], 'A description');
+  });
+
+  it('omits description when empty', async () => {
+    exec.on('rev-parse HEAD', { stdout: 'abc\n' });
+    exec.on('repo create', { stdout: 'https://github.com/alice/myrepo\n' });
+
+    await ipc.invoke('gh:repo-create', '/project', 'myrepo', 'alice', true, '');
+
+    const createCall = exec.calls.find(c => c.args.includes('create'));
+    assert.ok(!createCall.args.includes('--description'), 'should omit --description when empty');
+  });
+
+  it('propagates auth error', async () => {
+    exec.on('rev-parse HEAD', { stdout: 'abc\n' });
+    exec.on('repo create', { throws: 'gh auth login', stderr: 'error: not logged in' });
+
+    const result = await ipc.invoke('gh:repo-create', '/project', 'myrepo', 'alice', true, '');
+
+    assert.ok(!result.ok);
+    assert.ok(result.needsAuth, 'should set needsAuth on auth error');
+  });
+
+  it('returns ok:false on general error', async () => {
+    exec.on('rev-parse HEAD', { stdout: 'abc\n' });
+    exec.on('repo create', { throws: 'Name already exists', stderr: 'Name already exists on this account' });
+
+    const result = await ipc.invoke('gh:repo-create', '/project', 'myrepo', 'alice', true, '');
+
+    assert.ok(!result.ok);
+    assert.ok(!result.needsAuth);
+    assert.ok(result.error, 'should include error message');
+  });
+});
+
+describe('gh:list-accounts handler', () => {
+  let exec, ipc;
+
+  beforeEach(() => {
+    exec = mockExec();
+    installMocks(exec);
+    const { register } = loadModule('../main/github');
+    ipc = mockIpcMain();
+    register({ ipcMain: ipc });
+  });
+
+  it('returns user plus orgs', async () => {
+    // orgs rule must come first — mockExec uses substring matching so /user/orgs
+    // must be registered before /user to avoid the /user rule matching the orgs URL.
+    exec.on('/user/orgs', { stdout: JSON.stringify([{ login: 'myorg' }, { login: 'anotherorg' }]) });
+    exec.on('/user', { stdout: JSON.stringify({ login: 'alice', name: 'Alice' }) });
+
+    const result = await ipc.invoke('gh:list-accounts');
+
+    assert.ok(result.ok, `expected ok but got: ${result.error}`);
+    assert.ok(Array.isArray(result.accounts));
+    assert.equal(result.accounts[0].login, 'alice');
+    assert.equal(result.accounts[0].type, 'user');
+    assert.equal(result.accounts[1].login, 'myorg');
+    assert.equal(result.accounts[1].type, 'org');
+    assert.equal(result.accounts[2].login, 'anotherorg');
+    assert.equal(result.accounts[2].type, 'org');
+  });
+
+  it('returns only user when orgs call fails', async () => {
+    exec.on('/user/orgs', { throws: 'API error' });
+    exec.on('/user', { stdout: JSON.stringify({ login: 'alice' }) });
+
+    const result = await ipc.invoke('gh:list-accounts');
+
+    assert.ok(result.ok);
+    assert.equal(result.accounts.length, 1);
+    assert.equal(result.accounts[0].login, 'alice');
+  });
+
+  it('propagates auth error', async () => {
+    // /user/orgs and /user both fail — only need to stub the first call that throws
+    exec.on('/user', { throws: 'authentication required', stderr: 'gh auth login' });
+
+    const result = await ipc.invoke('gh:list-accounts');
+
+    assert.ok(!result.ok);
+    assert.ok(result.needsAuth);
+  });
+});

--- a/test/git-status-has-remote.test.js
+++ b/test/git-status-has-remote.test.js
@@ -1,0 +1,53 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { mockExec, installMocks, loadModule, mockIpcMain } = require('./helpers');
+
+describe('git:status hasRemote field', () => {
+  let exec, ipc;
+
+  beforeEach(() => {
+    exec = mockExec();
+    installMocks(exec);
+    const { register } = loadModule('../main/git-read');
+    ipc = mockIpcMain();
+    register({ ipcMain: ipc });
+  });
+
+  it('hasRemote is false when no remotes configured', async () => {
+    exec.on('rev-parse --git-dir', { stdout: '.git\n' });
+    exec.on('git remote', { stdout: '' });
+
+    const result = await ipc.invoke('git:status', '/repo');
+
+    assert.ok(result.isGit, 'should be a git repo');
+    assert.equal(result.hasRemote, false, 'hasRemote should be false when no remotes');
+  });
+
+  it('hasRemote is true when origin exists', async () => {
+    exec.on('rev-parse --git-dir', { stdout: '.git\n' });
+    exec.on('git remote', { stdout: 'origin\n' });
+
+    const result = await ipc.invoke('git:status', '/repo');
+
+    assert.ok(result.isGit);
+    assert.equal(result.hasRemote, true, 'hasRemote should be true when origin exists');
+  });
+
+  it('hasRemote is true when any remote exists', async () => {
+    exec.on('rev-parse --git-dir', { stdout: '.git\n' });
+    exec.on('git remote', { stdout: 'upstream\n' });
+
+    const result = await ipc.invoke('git:status', '/repo');
+
+    assert.equal(result.hasRemote, true);
+  });
+
+  it('hasRemote is false on a non-git directory', async () => {
+    exec.on('rev-parse --git-dir', { throws: 'not a git repository', stderr: 'not a git repository' });
+
+    const result = await ipc.invoke('git:status', '/not-a-repo');
+
+    assert.equal(result.isGit, false);
+    // hasRemote is undefined/false for non-git dirs — no assertion needed, just must not throw
+  });
+});


### PR DESCRIPTION
Closes #39

## Summary

Adds a "Publish to GitHub" workflow so users can create a GitHub repository from a local git repo (or right after `git init`) without leaving Braska. The modal collects repo name (pre-filled from folder basename), account/org, visibility, and an optional description, then calls `gh repo create` and wires up the `origin` remote.

## Spec

[specs/spec-20260519-create-github-repo-in-braska/spec.html](../blob/claude/sharp-gauss-LJLGz/specs/spec-20260519-create-github-repo-in-braska/spec.html)

## What changed

- **`main/github.js`** — two new IPC handlers:
  - `gh:repo-create(workDir, name, owner, isPrivate, description)` — calls `gh repo create <owner>/<name> --source . --remote origin [--push]`; skips `--push` when the repo has no commits yet
  - `gh:list-accounts()` — calls `gh api /user` + `gh api /user/orgs?per_page=100`; returns `[{ login, type }]` for the account picker
- **`main/git-read.js`** — `git:status` now includes `hasRemote: bool` (cheap local `git remote` read; no network)
- **`preload.js`** — exposes `window.github.repoCreate` and `window.github.listAccounts`
- **`renderer/publish-modal.js`** — new module; modal open/submit/close; pre-fills name from folder basename; loads accounts on open
- **`index.html`** — new `#publish-modal` using existing `.clone-modal-content` / `.wt-*` CSS classes
- **`styles.css`** — minimal additions for `#publish-modal` container and visibility radio row
- **`renderer/journey-cards.mjs`** — new "Publish to GitHub" card fires when `status.hasRemote === false`
- **`renderer/journey-zone.js`** — wires `publish-to-github` action to `openPublishModal`
- **`renderer/git-changes.js`** — opens publish modal immediately after `git:init` succeeds
- **`renderer/app.js`** — imports and inits `publish-modal`
- **`renderer/state.js`** — adds `publishBusy` flag to `modalState`

## Test plan

- [ ] `node --test test/gh-repo-create.test.js` → exit 0, 9/9 pass
- [ ] `node --test test/git-status-has-remote.test.js` → exit 0, 4/4 pass
- [ ] `node --test` → exit 0, 32/32 pass (no regressions)

## Routine notes

- Run: https://claude.ai/code/session_013GsMSZ4U2fgXfyjuBZqstW
- Draft because: two `assumed-uncertain` assumptions need human confirmation (1) default visibility should be private; (2) no-commits case currently shows a `window.alert()` — may prefer `showChangesStatus` instead. Open questions in spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_013GsMSZ4U2fgXfyjuBZqstW)_