### PR TITLE
[routine] git tab still shows changes after PR merge

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -270,7 +270,7 @@ initPostCommitPromptBridge();
 initGitHubViewBridge({ refreshGitHub, switchRightPanelTab });
 initJourneyZone({ doPush, doPullLatestMain, openBranchModal, refreshChanges, showChangesStatus, startTask, refreshWorktreeMetrics, loadProjects, openWorkDir, switchToGitHubView, showGitHubPRDetail });
 initGitHubPanel({ startTask, switchRightPanelTab, loadProjects, openWorkDir });
-initGitHubPRs({ loadProjects, openWorkDir, closeTab, tabsForWorkDir });
+initGitHubPRs({ loadProjects, openWorkDir, closeTab, tabsForWorkDir, refreshChanges });
 initTodoPanel({ loadProjects, openWorkDir, startTask, showGitHubIssueDetail, switchRightPanelTab, switchToGitHubView });
 initHoverLink();
 initCloneModal({ loadProjects, openWorkDir });

--- a/renderer/github-prs.js
+++ b/renderer/github-prs.js
@@ -4,13 +4,14 @@ import { tabState, ghState } from './state.js';
 import { escHtml, timeAgo } from './utils.js';
 import { ghResetListeners, ghChecksBadge, ghReviewBadge, ghStateBadge } from './github-panel.js';
 
-let _loadProjects, _openWorkDir, _closeTab, _tabsForWorkDir;
+let _loadProjects, _openWorkDir, _closeTab, _tabsForWorkDir, _refreshChanges;
 
-export function initGitHubPRs({ loadProjects, openWorkDir, closeTab, tabsForWorkDir }) {
+export function initGitHubPRs({ loadProjects, openWorkDir, closeTab, tabsForWorkDir, refreshChanges }) {
   _loadProjects = loadProjects;
   _openWorkDir = openWorkDir;
   _closeTab = closeTab;
   _tabsForWorkDir = tabsForWorkDir;
+  _refreshChanges = refreshChanges;
 }
 
 // ── PR list ────────────────────────────────────────────────────
@@ -175,12 +176,15 @@ export async function showGitHubPRDetail(workDir, number) {
         if (cleanDir === workDir) {
           // We were inside the removed worktree — switch to main
           _openWorkDir?.(r.mainWorktreePath);
+          _refreshChanges?.(r.mainWorktreePath || workDir);
         } else {
           // We're in a different worktree (e.g. main) — refresh the PR view
           showGitHubPRDetail(workDir, number);
+          _refreshChanges?.(workDir);
         }
       } else if (r.ok) {
         showGitHubPRDetail(workDir, number);
+        _refreshChanges?.(workDir);
       } else {
         mergeBtn.textContent = 'Error';
         const msg = document.createElement('div');

--- a/specs/spec-20260519-git-tab-sync-after-merge/baseline-verify.md
+++ b/specs/spec-20260519-git-tab-sync-after-merge/baseline-verify.md
@@ -1,0 +1,49 @@
+# Baseline Verify — pre-implementation
+
+Run on branch `claude/issue-26` before any implementation changes.
+
+## Command 1: Tests
+
+```
+node --test test/git-pull.test.js test/git-worktree.test.js test/journey-cards.test.mjs
+```
+
+**Exit code:** 0
+
+**Output (last 10 lines):**
+```
+1..3
+# tests 18
+# suites 3
+# pass 18
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 106.468071
+```
+
+## Command 2: refreshChanges in github-prs.js
+
+```
+grep -n "refreshChanges" renderer/github-prs.js
+```
+
+**Exit code:** 1 (no match — expected; this confirms the gap being fixed)
+
+**Output:** (empty)
+
+## Command 3: refreshChanges in initGitHubPRs call
+
+```
+grep -n "refreshChanges" renderer/app.js | grep "initGitHubPRs"
+```
+
+**Exit code:** 1 (no match — expected; this confirms the injection is missing)
+
+**Output:** (empty)
+
+## Notes
+
+- `npm test` (which runs `node --test test/`) fails pre-existing in this environment with "Cannot find module '/home/user/braska/test'" — Node 22 directory-glob behaviour issue. Individual test files pass. Spec Verify block updated to use individual file invocations.
+- Commands 2 and 3 exit 1 at baseline — this is the expected pre-fix state, not a regression. After implementation they must exit 0 (match found).

--- a/specs/spec-20260519-git-tab-sync-after-merge/research.md
+++ b/specs/spec-20260519-git-tab-sync-after-merge/research.md
@@ -1,0 +1,55 @@
+# Research — git UI sync after push/merge (#26)
+
+## Problem summary
+
+After a PR is merged via GitHub, the changes panel continues to display "changes to push" rather than reflecting that the branch is up-to-date. The root cause is that the merge success handler in `renderer/github-prs.js` re-renders the PR detail view but does not call `refreshChanges()` for the active worktree. The `git-watcher` only fires on `.git/HEAD` changes and worktree structure changes, so remote-ref deletions and upstream merges that don't alter the local HEAD never trigger an automatic status recompute.
+
+## Approaches considered
+
+**1. Add explicit `refreshChanges()` after PR merge in renderer**
+- After `window.github.prMerge()` succeeds, call `refreshChanges(workDir)` in `github-prs.js`.
+- Pros: Surgical, minimal change; mirrors the existing pattern in `doPush()`.
+- Cons: Only fixes the merge-via-braska path; doesn't catch external merges or other git operations.
+
+**2. Extend git-watcher to emit on remote-tracking ref updates**
+- Watch `.git/refs/remotes/` for changes to catch remote ref deletions and upstream merges.
+- Pros: Architectural; catches all remote-state changes.
+- Cons: High noise risk; CLAUDE.md notes a past infinite-refresh bug (2026-03-29) from fs.watch inside list handlers. High implementation risk.
+
+**3. Use existing `git:fetched` broadcast to always trigger a status refresh**
+- `git-fetcher` already broadcasts `git:fetched`; extend `app.js` listener to call `refreshChanges()` for the active worktree unconditionally.
+- Pros: Covers post-merge state within 5 minutes; no new IPC needed.
+- Cons: 5-minute worst-case latency; unhelpful for immediate post-merge feedback.
+
+**4. Track merge metadata and refresh on GitHub panel exit**
+- Store merge result, then trigger `refreshChanges()` when user navigates away.
+- Pros: Non-blocking.
+- Cons: Subtle timing; misses users who keep the panel open; doesn't solve other gaps.
+
+## Recommended approach
+
+**Approach 1 as the primary fix**, plus a targeted audit of other git operations that already have a clear gap.
+
+The `doPush()` function in `renderer/git-changes.js` already calls `refreshChanges(workDir)` after a push — the merge handler simply needs the same treatment. The existing `git:fetched` listener in `app.js` (lines 230–237) also calls `refreshChanges()` after fetch, so the background-polling path is already partially wired. The immediate gap is the PR merge success handler.
+
+Secondary: also check `gh:pr-merge` in `main/github.js` — it deletes the local branch on merge but does not emit any signal to trigger a renderer refresh.
+
+## Unknowns
+
+- Whether other git operations (rebase, worktree merge, branch delete via sidebar) have the same pattern gap — need to audit each handler.
+- Whether `gitState.mergedToMain` in `renderer/state.js` (line 87) was intended for tracking this but was never wired up.
+- Whether `git:fetched` reliably reaches the renderer when the app is backgrounded (may depend on window visibility/focus state).
+
+## Files inventory
+
+| File | Relevance |
+|------|-----------|
+| `renderer/github-prs.js` | PR detail view; merge button handler (line ~162–191) is the primary gap — no `refreshChanges()` call after merge. |
+| `renderer/git-changes.js` | Implements `refreshChanges()`; `doPush()` shows the correct post-op refresh pattern. |
+| `renderer/app.js` | Registers `git:fetched` listener (lines 230–237) that calls `refreshChanges()` — shows the mechanism works when triggered. |
+| `main/github.js` | `gh:pr-merge` IPC handler; deletes local branch after merge but doesn't broadcast a git-state change to the renderer. |
+| `main/git-watcher.js` | Watches `.git/HEAD` and worktree structure; doesn't cover remote ref changes or upstream merges. |
+| `main/git-read.js` | Computes `pushAhead` for the changes panel; correct logic, just not triggered after merge. |
+| `renderer/state.js` | Contains `gitState.mergedToMain` — possibly intended for this pattern, never wired. |
+| `renderer/git-changes-modals.js` | Post-pull-latest refresh pattern: calls `_refreshChanges()` + `_refreshWorktreeMetrics()` — the template for what merge completion should do. |
+| `renderer/journey-zone.js` | Calls `refreshChanges()` on PR pill click; not on merge completion. |

--- a/specs/spec-20260519-git-tab-sync-after-merge/spec.md
+++ b/specs/spec-20260519-git-tab-sync-after-merge/spec.md
@@ -40,7 +40,7 @@ No new test file. The change is a three-line addition to a DOM/IPC-coupled event
 ## Verify
 
 ```bash
-npm test
+node --test test/git-pull.test.js test/git-worktree.test.js test/journey-cards.test.mjs
 grep -n "refreshChanges" renderer/github-prs.js
 grep -n "refreshChanges" renderer/app.js | grep "initGitHubPRs"
 ```

--- a/specs/spec-20260519-git-tab-sync-after-merge/spec.md
+++ b/specs/spec-20260519-git-tab-sync-after-merge/spec.md
@@ -2,7 +2,7 @@
 
 Issue: [#26](https://github.com/derek-hobden/braska/issues/26) · PR: [#50](https://github.com/derek-hobden/braska/pull/50) · branch: `claude/issue-26` · started: 2026-05-19T00:00:00Z
 
-**Status:** Spec drafted; implementation not started.
+**Status:** Implementation complete; awaiting final verify.
 
 ## Issue body
 
@@ -33,9 +33,9 @@ No new test file. The change is a three-line addition to a DOM/IPC-coupled event
 
 ## Tasks
 
-- [ ] **▶ Active** — Inject `refreshChanges` into `initGitHubPRs` and call it after all merge success paths in `renderer/github-prs.js`
+- [x] Inject `refreshChanges` into `initGitHubPRs` and call it after all merge success paths in `renderer/github-prs.js`
   - _Story: As a user, when I merge a PR via the braska GitHub panel, the branch subtitle and changes section immediately reflect the true git state._
-- [ ] Update `renderer/app.js` to pass `refreshChanges` into the `initGitHubPRs()` call
+- [x] Update `renderer/app.js` to pass `refreshChanges` into the `initGitHubPRs()` call
 
 ## Verify
 

--- a/specs/spec-20260519-git-tab-sync-after-merge/spec.md
+++ b/specs/spec-20260519-git-tab-sync-after-merge/spec.md
@@ -1,0 +1,86 @@
+# Spec — after pushing to git, opening pr, and merging. the git tab still shows changes to be pushed (#26)
+
+Issue: [#26](https://github.com/derek-hobden/braska/issues/26) · PR: [#50](https://github.com/derek-hobden/braska/pull/50) · branch: `claude/issue-26` · started: 2026-05-19T00:00:00Z
+
+**Status:** Spec drafted; implementation not started.
+
+## Issue body
+
+> after pushing to git, opening pr, and merging. the git tab still shows changes to be pushed
+>
+> this leads me to believe we have sync issues between the UI and the actual true git status all over the application
+
+## Chosen approach
+
+The merge button handler in `renderer/github-prs.js` calls `window.github.prMerge()` and on success only re-renders the PR detail view or switches worktrees — it never calls `refreshChanges()`. This leaves the branch subtitle ("X unpushed") and the changes section stale. The fix is to inject `refreshChanges` into `initGitHubPRs` (mirroring how the post-push flow already works) and call it with the appropriate `workDir` in all three success branches of the merge handler. This is a three-line addition to the renderer following an existing pattern (`onPushSuccess` in `git-changes.js` calls `refreshChanges(workDir)` after every push).
+
+## Assumptions
+
+- ✓ **confident** — `refreshChanges(workDir)` is safe to call speculatively after any git operation: it's idempotent, already debounce-guarded by a generation counter (`_refreshGen`), and the existing push flow calls it the same way.
+- ✓ **confident** — The `worktreeCleanedUp && cleanDir === workDir` branch in the merge handler switches to main via `_openWorkDir(r.mainWorktreePath)`, but `openWorkDir` only calls `refreshChanges` when the active right-panel is already 'changes'. Since the user is on the GitHub panel when merging, the branch subtitle stays stale. Calling `refreshChanges(r.mainWorktreePath)` after `_openWorkDir` ensures it is updated.
+- ✓ **confident** — `refreshChanges` is already exported from `git-changes.js` and imported in `app.js`; adding it to the `initGitHubPRs` injection is a one-line change.
+
+## Definition of done
+
+- After merging a PR (any of the three merge handler branches), the branch subtitle in the git changes panel no longer shows a stale "X unpushed" count.
+- `npm test` exits 0.
+- `renderer/github-prs.js` contains a call to `refreshChanges` in the merge success handler.
+- `renderer/app.js` passes `refreshChanges` into `initGitHubPRs`.
+
+## Up-front tests
+
+No new test file. The change is a three-line addition to a DOM/IPC-coupled event handler. The existing test suite (`node:test`) covers pure functions; writing a meaningful test for this handler would require mocking Electron's `window.github`, the DOM, and `refreshChanges` — which is not the project's test style and would be performative. Correctness is verified by inspecting the grep output in the Verify block (see TDD carve-out entry in Decisions).
+
+## Tasks
+
+- [ ] **▶ Active** — Inject `refreshChanges` into `initGitHubPRs` and call it after all merge success paths in `renderer/github-prs.js`
+  - _Story: As a user, when I merge a PR via the braska GitHub panel, the branch subtitle and changes section immediately reflect the true git state._
+- [ ] Update `renderer/app.js` to pass `refreshChanges` into the `initGitHubPRs()` call
+
+## Verify
+
+```bash
+npm test
+grep -n "refreshChanges" renderer/github-prs.js
+grep -n "refreshChanges" renderer/app.js | grep "initGitHubPRs"
+```
+
+## Decisions
+
+_Appended chronologically as implementation reveals choices._
+
+**TDD carve-out (2026-05-19):** Test-first skipped for the merge handler change. The handler is tightly coupled to `window.github` (IPC), the DOM, and callback injections. A test would be a mock-heavy integration stub that doesn't reflect the project's `node:test` style (pure function tests). Bar is "test would be performative" — that bar is met here.
+
+## Don'ts (rejected approaches)
+
+**Extending git-watcher:** Watching `.git/refs/remotes/` for remote-ref deletions was considered. Rejected due to the past infinite-refresh bug documented in CLAUDE.md (2026-03-29). High false-positive risk from the noisy `.git/` subtree.
+
+**5-minute fetch polling:** `git-fetcher` already calls `refreshChanges` via the `git:fetched` listener. Relying on this for post-merge sync would leave a worst-case 5-minute stale window. Not appropriate as the sole fix.
+
+## Course corrections
+
+_None yet._
+
+## Subagent notes
+
+Research subagent confirmed:
+- Primary gap: `renderer/github-prs.js` merge handler (lines 169–191) never calls `refreshChanges()`.
+- Pattern to follow: `onPushSuccess()` in `renderer/git-changes.js` (line 362–367).
+- `openWorkDir()` in `app.js` calls `refreshRightPanel()` which only dispatches to `refreshChanges` if the active panel is already 'changes'. Since the user is on GitHub panel when merging, this doesn't cover the case.
+- `gitState.mergedToMain` in `renderer/state.js` appears to be dead code — not wired to any refresh logic.
+
+## Follow-ups (deferred work)
+
+_None yet._
+
+## Open questions
+
+_None._
+
+## Baseline verify (pre-implementation)
+
+_Populated at end of Phase 2._
+
+## Verification results (post-implementation)
+
+_Populated in Phase 4._

--- a/specs/spec-20260519-git-tab-sync-after-merge/spec.md
+++ b/specs/spec-20260519-git-tab-sync-after-merge/spec.md
@@ -2,7 +2,7 @@
 
 Issue: [#26](https://github.com/derek-hobden/braska/issues/26) · PR: [#50](https://github.com/derek-hobden/braska/pull/50) · branch: `claude/issue-26` · started: 2026-05-19T00:00:00Z
 
-**Status:** Implementation complete; awaiting final verify.
+**Status:** Complete; ready for review.
 
 ## Issue body
 

--- a/specs/spec-20260519-git-tab-sync-after-merge/verify-results.md
+++ b/specs/spec-20260519-git-tab-sync-after-merge/verify-results.md
@@ -1,0 +1,63 @@
+# Verification Results — post-implementation
+
+Run on branch `claude/issue-26` after all implementation commits.
+
+## Command 1: Tests
+
+```
+node --test test/git-pull.test.js test/git-worktree.test.js test/journey-cards.test.mjs
+```
+
+**Exit code:** 0
+
+**Output (last 10 lines):**
+```
+1..3
+# tests 18
+# suites 3
+# pass 18
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 99.060757
+```
+
+**vs baseline:** Same pass count (18/18). No regression.
+
+## Command 2: refreshChanges in github-prs.js
+
+```
+grep -n "refreshChanges" renderer/github-prs.js
+```
+
+**Exit code:** 0 (was 1 at baseline — now correctly exits 0)
+
+**Output:**
+```
+7:let _loadProjects, _openWorkDir, _closeTab, _tabsForWorkDir, _refreshChanges;
+9:export function initGitHubPRs({ loadProjects, openWorkDir, closeTab, tabsForWorkDir, refreshChanges }) {
+14:  _refreshChanges = refreshChanges;
+179:          _refreshChanges?.(r.mainWorktreePath || workDir);
+183:          _refreshChanges?.(workDir);
+187:        _refreshChanges?.(workDir);
+```
+
+Three call sites present covering all three merge success branches.
+
+## Command 3: refreshChanges in initGitHubPRs call
+
+```
+grep -n "refreshChanges" renderer/app.js | grep "initGitHubPRs"
+```
+
+**Exit code:** 0 (was 1 at baseline — now correctly exits 0)
+
+**Output:**
+```
+273:initGitHubPRs({ loadProjects, openWorkDir, closeTab, tabsForWorkDir, refreshChanges });
+```
+
+## Summary
+
+All verify commands green. No new failures vs baseline. Pre-existing `npm test` directory-resolution failure is unchanged and unrelated to this fix.


### PR DESCRIPTION
Closes #26

Status: **spec drafted; implementing**

Spec: [`specs/spec-20260519-git-tab-sync-after-merge/spec.md`](https://github.com/derek-hobden/braska/blob/claude/issue-26/specs/spec-20260519-git-tab-sync-after-merge/spec.md)

Routine session: https://claude.ai/code/session_01MDce63da9CscKgmfwfF5bK

Watch the commit log for task progress. Reply on this PR to answer questions or unblock.