### PR TITLE
github panel: open items on github.com from row hover or cmd-click

### DIFF
--- a/main/github.js
+++ b/main/github.js
@@ -130,7 +130,7 @@ function register({ ipcMain }) {
       const { stdout: branchOut } = await execFileAsync('git', ['symbolic-ref', '--short', 'HEAD'], { cwd: workDir, encoding: 'utf-8', timeout: 5000 });
       const branch = branchOut.trim();
       const { stdout } = await execFileAsync('gh', [
-        'pr', 'list', '--head', branch, '--json', 'number,url,statusCheckRollup', '--limit', '1'
+        'pr', 'list', '--head', branch, '--json', 'number,url,statusCheckRollup,mergeable,isDraft', '--limit', '1'
       ], { cwd: workDir, encoding: 'utf-8', timeout: 10000 });
       const prs = JSON.parse(stdout);
       return { ok: true, pr: prs.length ? prs[0] : null };

--- a/main/github.js
+++ b/main/github.js
@@ -15,6 +15,22 @@ function isAuthError(err) {
 const REPO_REF_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]+$/;
 const NAME_RE = /^[A-Za-z0-9][\w.-]*$/;  // single component of owner or repo name
 
+// REST /notifications returns subject.url as the API URL (api.github.com/repos/...);
+// the html URL must be derived from subject.url + subject.type. Returns null for
+// Release/Discussion/unknown patterns so the renderer can omit the link affordance
+// rather than synthesise a broken URL.
+const NOTIF_SUBJECT_RE = /^https:\/\/api\.([^/]+)\/repos\/([^/]+)\/([^/]+)\/(issues|pulls|commits)\/([^/]+)\/?$/;
+const NOTIF_PATH_REWRITE = { issues: 'issues', pulls: 'pull', commits: 'commit' };
+function notificationSubjectToHtmlUrl(apiUrl, _type) {
+  if (typeof apiUrl !== 'string') return null;
+  const m = apiUrl.match(NOTIF_SUBJECT_RE);
+  if (!m) return null;
+  const [, host, owner, repo, kind, id] = m;
+  const segment = NOTIF_PATH_REWRITE[kind];
+  if (!segment) return null;
+  return `https://${host}/${owner}/${repo}/${segment}/${id}`;
+}
+
 function register({ ipcMain }) {
   ipcMain.handle('gh:auth-status', async (_event, workDir) => {
     let authenticated = false, user = '';
@@ -290,7 +306,14 @@ function register({ ipcMain }) {
     try {
       const { stdout: nwo } = await execFileAsync('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], { cwd: workDir, encoding: 'utf-8', timeout: 10000 });
       const { stdout } = await execFileAsync('gh', ['api', `repos/${nwo.trim()}/notifications`, '--cache', '60s'], { cwd: workDir, encoding: 'utf-8', timeout: 15000 });
-      return { ok: true, data: JSON.parse(stdout) };
+      const raw = JSON.parse(stdout);
+      const data = Array.isArray(raw)
+        ? raw.map(n => ({
+            ...n,
+            htmlUrl: notificationSubjectToHtmlUrl((n.subject || {}).url, (n.subject || {}).type),
+          }))
+        : raw;
+      return { ok: true, data };
     } catch (err) { return { ok: false, error: err.stderr || err.message }; }
   });
 
@@ -373,4 +396,4 @@ function register({ ipcMain }) {
   });
 }
 
-module.exports = { register };
+module.exports = { register, notificationSubjectToHtmlUrl };

--- a/renderer/github-issues.js
+++ b/renderer/github-issues.js
@@ -1,8 +1,8 @@
 // ── GitHub Issues — list, detail, create + edit forms ──
 
 import { tabState, ghState } from './state.js';
-import { escHtml, timeAgo, ghSafeColor, getProjectRootForWorkDir } from './utils.js';
-import { ghResetListeners, ghLabelHtml, ghStateBadge } from './github-panel.js';
+import { escHtml, timeAgo, ghSafeColor, getProjectRootForWorkDir, ghExtLink } from './utils.js';
+import { ghResetListeners, ghLabelHtml, ghStateBadge, handleGhExternalClick } from './github-panel.js';
 import { showGitHubIssueForm } from './github-issues-create.js';
 
 // ── Injected deps ──────────────────────────────────────────────
@@ -54,11 +54,12 @@ export async function refreshGitHubIssues(workDir) {
       if (issue.labels && issue.labels.length) {
         for (const l of issue.labels) labels += ghLabelHtml(l);
       }
-      html += `<div class="gh-item" data-gh-issue-number="${issue.number}">
+      html += `<div class="gh-item" data-gh-issue-number="${issue.number}" data-gh-row-url="${escHtml(issue.url || '')}">
         <span class="gh-item-number">#${issue.number}</span>
         <span class="gh-item-title">${escHtml(issue.title)}</span>
         ${labels}
         ${ghStateBadge(issue.state)}
+        ${ghExtLink(issue.url)}
       </div>`;
     }
   }
@@ -66,6 +67,7 @@ export async function refreshGitHubIssues(workDir) {
   content.innerHTML = html;
 
   content.addEventListener('click', (e) => {
+    if (handleGhExternalClick(e)) return;
     const filterBtn = e.target.closest('.gh-filter-btn[data-gh-issue-filter]');
     if (filterBtn) {
       ghState.issueFilter = filterBtn.dataset.ghIssueFilter;

--- a/renderer/github-panel.js
+++ b/renderer/github-panel.js
@@ -3,7 +3,7 @@
 // PRs and issues are in github-prs.js and github-issues.js.
 
 import { tabState, ghState } from './state.js';
-import { escHtml, timeAgo } from './utils.js';
+import { escHtml, timeAgo, ghExtLink } from './utils.js';
 import { refreshGitHubPRs } from './github-prs.js';
 import { refreshGitHubIssues, showGitHubIssueDetail, initGitHubIssues } from './github-issues.js';
 import { openCreateRepoModal } from './github-repo-create-modal.js';
@@ -22,6 +22,31 @@ export function ghResetListeners() {
   if (ghState.contentAC) ghState.contentAC.abort();
   ghState.contentAC = new AbortController();
   return ghState.contentAC.signal;
+}
+
+// Intercepts the two "open on GitHub" affordances every list section shares:
+// (1) click on a [data-gh-external-url] button; (2) cmd-click on a row that
+// carries [data-gh-row-url]. Returns true when the event was handled so the
+// caller can short-circuit its detail-open / filter behaviour.
+export function handleGhExternalClick(e) {
+  const extBtn = e.target.closest('[data-gh-external-url]');
+  if (extBtn) {
+    const url = extBtn.dataset.ghExternalUrl;
+    if (url) window.windowActions.openExternal(url);
+    e.preventDefault();
+    e.stopPropagation();
+    return true;
+  }
+  if (e.metaKey) {
+    const row = e.target.closest('[data-gh-row-url]');
+    const url = row && row.dataset.ghRowUrl;
+    if (url) {
+      window.windowActions.openExternal(url);
+      e.preventDefault();
+      return true;
+    }
+  }
+  return false;
 }
 
 export function ghChecksBadge(rollup) {
@@ -117,13 +142,26 @@ export async function refreshGitHub(workDir) {
     return;
   }
 
-  let html = `<div class="gh-subnav">
+  const repo = ghState.cachedAuth.repo;
+  const repoLabel = repo && repo.owner && repo.name ? `${repo.owner.login || repo.owner}/${repo.name}` : '';
+  const repoUrl = repo && repo.url;
+  const repoHeader = repoLabel
+    ? `<div class="gh-repo-header" data-gh-row-url="${escHtml(repoUrl || '')}"><span class="gh-repo-header-name">${escHtml(repoLabel)}</span>${ghExtLink(repoUrl)}</div>`
+    : '';
+
+  let html = `${repoHeader}<div class="gh-subnav">
     <button class="gh-subnav-btn${ghState.section === 'prs' ? ' active' : ''}" data-gh-section="prs">PRs</button>
     <button class="gh-subnav-btn${ghState.section === 'issues' ? ' active' : ''}" data-gh-section="issues">Issues</button>
     <button class="gh-subnav-btn${ghState.section === 'ci' ? ' active' : ''}" data-gh-section="ci">CI</button>
     <button class="gh-subnav-btn${ghState.section === 'notifs' ? ' active' : ''}" data-gh-section="notifs">Notifications</button>
   </div><div id="gh-content"></div>`;
   ghBody.innerHTML = html;
+
+  if (repoHeader) {
+    ghBody.querySelector('.gh-repo-header').addEventListener('click', (e) => {
+      handleGhExternalClick(e);
+    });
+  }
 
   ghBody.querySelector('.gh-subnav').addEventListener('click', (e) => {
     const btn = e.target.closest('.gh-subnav-btn');
@@ -187,11 +225,12 @@ async function refreshGitHubCI(workDir, opts = {}) {
       const icon = run.conclusion === 'success' ? '<span style="color:#3fb950">&#10003;</span>' :
                    run.conclusion === 'failure' ? '<span style="color:#f85149">&#10007;</span>' :
                    '<span style="color:#d29922">&#9679;</span>';
-      html += `<div class="gh-ci-item" data-gh-run-id="${run.databaseId}">
+      html += `<div class="gh-ci-item" data-gh-run-id="${run.databaseId}" data-gh-row-url="${escHtml(run.url || '')}">
         ${icon}
         <span class="gh-ci-title">${escHtml(run.displayTitle)}</span>
         <span class="gh-badge gh-badge-${statusCls}">${escHtml(run.conclusion || run.status || 'pending')}</span>
         <span class="gh-ci-time">${timeAgo(run.createdAt)}</span>
+        ${ghExtLink(run.url)}
       </div>`;
     }
   }
@@ -199,6 +238,7 @@ async function refreshGitHubCI(workDir, opts = {}) {
   content.innerHTML = html;
 
   content.addEventListener('click', (e) => {
+    if (handleGhExternalClick(e)) return;
     if (e.target.closest('#gh-ci-refresh-btn')) {
       refreshGitHubCI(tabState.activeWorkDir);
       return;
@@ -290,11 +330,13 @@ async function refreshGitHubNotifs(workDir) {
       const typeIcon = subject.type === 'PullRequest' ? '<span style="color:#a371f7">PR</span>' :
                        subject.type === 'Issue' ? '<span style="color:#3fb950">I</span>' :
                        '<span style="color:#888">N</span>';
-      html += `<div class="gh-notif-item">
+      const rowUrlAttr = n.htmlUrl ? ` data-gh-row-url="${escHtml(n.htmlUrl)}"` : '';
+      html += `<div class="gh-notif-item"${rowUrlAttr}>
         ${typeIcon}
         <span class="gh-notif-title">${escHtml(subject.title || 'Notification')}</span>
         <span class="gh-notif-reason">${escHtml(n.reason || '')}</span>
         <span class="gh-notif-time">${timeAgo(n.updated_at)}</span>
+        ${ghExtLink(n.htmlUrl)}
       </div>`;
     }
   }
@@ -302,6 +344,7 @@ async function refreshGitHubNotifs(workDir) {
   content.innerHTML = html;
 
   content.addEventListener('click', async (e) => {
+    if (handleGhExternalClick(e)) return;
     if (e.target.closest('#gh-notif-refresh-btn')) {
       refreshGitHubNotifs(tabState.activeWorkDir);
       return;

--- a/renderer/github-prs.js
+++ b/renderer/github-prs.js
@@ -1,8 +1,8 @@
 // ── GitHub PRs — list, detail, create form ──
 
 import { tabState, ghState } from './state.js';
-import { escHtml, timeAgo } from './utils.js';
-import { ghResetListeners, ghChecksBadge, ghReviewBadge, ghStateBadge } from './github-panel.js';
+import { escHtml, timeAgo, ghExtLink } from './utils.js';
+import { ghResetListeners, ghChecksBadge, ghReviewBadge, ghStateBadge, handleGhExternalClick } from './github-panel.js';
 
 let _loadProjects, _openWorkDir, _closeTab, _tabsForWorkDir, _refreshChanges;
 
@@ -48,12 +48,13 @@ export async function refreshGitHubPRs(workDir) {
     html += '<div class="gh-empty">No pull requests found</div>';
   } else {
     for (const pr of result.data) {
-      html += `<div class="gh-item" data-gh-pr-number="${pr.number}">
+      html += `<div class="gh-item" data-gh-pr-number="${pr.number}" data-gh-row-url="${escHtml(pr.url || '')}">
         <span class="gh-item-number">#${pr.number}</span>
         <span class="gh-item-title">${escHtml(pr.title)}</span>
         ${ghStateBadge(pr.state, pr.isDraft)}
         ${ghChecksBadge(pr.statusCheckRollup)}
         ${ghReviewBadge(pr.reviewDecision)}
+        ${ghExtLink(pr.url)}
       </div>`;
     }
   }
@@ -61,6 +62,7 @@ export async function refreshGitHubPRs(workDir) {
   content.innerHTML = html;
 
   content.addEventListener('click', (e) => {
+    if (handleGhExternalClick(e)) return;
     const filterBtn = e.target.closest('.gh-filter-btn[data-gh-pr-filter]');
     if (filterBtn) {
       ghState.prFilter = filterBtn.dataset.ghPrFilter;

--- a/renderer/sidebar.js
+++ b/renderer/sidebar.js
@@ -128,11 +128,13 @@ const CI_POLL_MS = 25000;
 
 const SVG_CI_PASS = '<svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="8" fill="currentColor"/><path d="M11.78 6.28a.75.75 0 0 0-1.06-1.06L6.75 9.19 5.28 7.72a.75.75 0 1 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0z"/></svg>';
 const SVG_CI_FAIL = '<svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="8" fill="currentColor"/><path d="M5.72 5.72a.75.75 0 0 1 1.06 0L8 6.94l1.22-1.22a.75.75 0 1 1 1.06 1.06L9.06 8l1.22 1.22a.75.75 0 1 1-1.06 1.06L8 9.06l-1.22 1.22a.75.75 0 0 1-1.06-1.06L6.94 8 5.72 6.78a.75.75 0 0 1 0-1.06z"/></svg>';
+const SVG_CI_CONFLICT = '<svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true"><path d="M7.13 2.5L1.5 13a1 1 0 0 0 .87 1.5h11.26a1 1 0 0 0 .87-1.5L8.87 2.5a1 1 0 0 0-1.74 0z" fill="currentColor"/><path d="M7.25 6.75a.75.75 0 0 1 1.5 0v3a.75.75 0 0 1-1.5 0v-3zM8 11.25a.875.875 0 1 1 0 1.75.875.875 0 0 1 0-1.75z"/></svg>';
 
 function ciBadgeHtml(status) {
-  if (status === 'pass') return `<span class="wt-ci-glyph pass" title="CI checks passing">${SVG_CI_PASS}</span>`;
+  if (status === 'pass') return `<span class="wt-ci-glyph pass" title="Ready to merge">${SVG_CI_PASS}</span>`;
   if (status === 'fail') return `<span class="wt-ci-glyph fail" title="CI checks failing">${SVG_CI_FAIL}</span>`;
   if (status === 'pending') return '<span class="wt-ci-dot pending" title="CI checks in progress"></span>';
+  if (status === 'conflict') return `<span class="wt-ci-glyph conflict" title="Merge conflict">${SVG_CI_CONFLICT}</span>`;
   return '';
 }
 
@@ -145,8 +147,7 @@ export async function refreshCIBadges() {
     const wtPath = slot.dataset.wtPath;
     try {
       const prResult = await window.github.prForBranch(wtPath);
-      const rollup = prResult?.pr?.statusCheckRollup;
-      slot.innerHTML = rollup ? ciBadgeHtml(prCheckStatus(rollup)) : '';
+      slot.innerHTML = prResult?.pr ? ciBadgeHtml(prCheckStatus(prResult.pr)) : '';
     } catch { slot.innerHTML = ''; }
   }
   scheduleCIPoll();

--- a/renderer/utils.js
+++ b/renderer/utils.js
@@ -357,8 +357,13 @@ export function getProjectRootForWorkDir(workDir) {
 }
 
 // StatusContext items have no .conclusion field — ghChecksBadge misreads them as pending; handle both types explicitly.
-export function prCheckStatus(rollup) {
-  if (!rollup || !rollup.length) return null;
+export function prCheckStatus(pr) {
+  if (!pr) return null;
+  if (pr.mergeable === 'CONFLICTING') return 'conflict';
+  const rollup = pr.statusCheckRollup;
+  if (!rollup || !rollup.length) {
+    return (pr.mergeable === 'MERGEABLE' && !pr.isDraft) ? 'pass' : null;
+  }
   for (const c of rollup) {
     if (c.__typename === 'StatusContext') {
       if (c.state === 'FAILURE' || c.state === 'ERROR') return 'fail';

--- a/renderer/utils.js
+++ b/renderer/utils.js
@@ -30,6 +30,8 @@ export const SVG_STYLE = '<svg viewBox="0 0 24 24" fill="none" stroke="currentCo
 
 export const SVG_TEXT = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/></svg>';
 
+export const SVG_EXTERNAL_LINK = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>';
+
 // Tab-type icons — match the tab-type-picker for visual consistency.
 export const SVG_TAB_CLAUDE = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>';
 export const SVG_TAB_TERMINAL = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>';
@@ -145,6 +147,15 @@ export function ghSafeColor(raw) {
   if (typeof raw !== 'string') return '666666';
   if (/^[0-9a-fA-F]{3}$/.test(raw)) return raw[0]+raw[0]+raw[1]+raw[1]+raw[2]+raw[2];
   return /^[0-9a-fA-F]{6}$/.test(raw) ? raw : '666666';
+}
+
+/** Render the "open on GitHub" external-link icon button for an item row.
+ *  Returns an empty string when url is falsy — callers can interpolate
+ *  unconditionally. The button carries data-gh-external-url so a single
+ *  delegated listener per panel can handle every section. */
+export function ghExtLink(url) {
+  if (!url) return '';
+  return `<button class="gh-ext-link" data-gh-external-url="${escHtml(url)}" title="Open on GitHub" tabindex="-1">${SVG_EXTERNAL_LINK}</button>`;
 }
 
 /** Convert an agent name (e.g. '__CLAUDE__', 'code-reviewer') to a display name. */

--- a/specs/spec-20260520-open-github-items-in-browser/baseline-verify.md
+++ b/specs/spec-20260520-open-github-items-in-browser/baseline-verify.md
@@ -1,0 +1,37 @@
+# Baseline verify
+Captured: 2026-05-20T08:36:00Z
+Base commit: 06a379b1562caa88681564934ffe3346b82a7fcc
+
+## $ node --test test/*.test.js test/*.test.mjs
+exit: 0
+▶ ISSUE_BRANCH_RE
+  ✔ matches gh-issue-N (original UI-created format) (0.602916ms)
+  ✔ matches claude/issue-N (agent-created format) (0.111667ms)
+  ✔ matches bare issue-N (0.067709ms)
+  ✔ extracts the correct number (0.056833ms)
+  ✔ does not match main (0.051541ms)
+  ✔ does not match a plain feature branch (0.048459ms)
+✔ ISSUE_BRANCH_RE (1.723208ms)
+▶ computeJourneyCards
+  ✔ shows pull-remote card when pushBehind > 0 and NO dirty files (0.767209ms)
+  ✔ does NOT show pull-remote card when pushBehind > 0 AND dirty files exist (0.081125ms)
+  ✔ shows commit card when dirty files exist (0.064208ms)
+  ✔ shows only conflicts card when conflicted files exist (0.771667ms)
+  ✔ shows behind-main card when behind > 0 and clean (0.071416ms)
+  ✔ shows push card when pushAhead > 0 with upstream (0.06275ms)
+  ✔ shows share card for unpublished feature branch with commits (0.065666ms)
+  ✔ shows post-merge card when mergeInfo is provided (0.073042ms)
+  ✔ returns empty array when nothing is actionable (0.089292ms)
+  ✔ diverged state — shows sync card when pushAhead > 0 and pushBehind > 0 (clean) (0.1195ms)
+  ✔ diverged state — does NOT show separate pull-remote or share cards when diverged (0.065292ms)
+  ✔ diverged state — dirty files still show commit card (not sync card) (0.072333ms)
+✔ computeJourneyCards (3.560709ms)
+ℹ tests 68
+ℹ suites 11
+ℹ pass 68
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 233.723709
+

--- a/specs/spec-20260520-open-github-items-in-browser/research.md
+++ b/specs/spec-20260520-open-github-items-in-browser/research.md
@@ -1,0 +1,73 @@
+# Research — Open GitHub items in browser from the GitHub panel (#66)
+
+## Problem summary
+
+The right-side GitHub panel surfaces five item types — the repo, PRs, issues, CI/workflow runs, and notifications. None of them currently offer any way to jump to the corresponding github.com page in the default browser. The user wants a consistent affordance across all five item types: discoverable once, works everywhere.
+
+## Approaches considered
+
+1. **Cmd-click only.** Match the `renderer/terminals.js:66` pattern. Quick, ~3 lines. Downside: invisible to anyone who doesn't know to try it.
+2. **Always-visible external-link icon.** Discoverable, but adds visual noise to dense list rows.
+3. **Always-visible icon + cmd-click.** Most discoverable, but doubles the affordance footprint.
+4. **Hover-visible icon + cmd-click on the row.** Discoverable on hover (the issue text explicitly mentions "on hover"), invisible at rest, plus a power-user shortcut. **← chosen.**
+5. **Right-click context menu via Electron `Menu.popup()`.** Cleanest mouse-only UX but a new IPC channel + menu wiring per row type. Out of scope for #66.
+
+## Recommended approach
+
+- One SVG external-link icon (`SVG_EXTERNAL_LINK`) in `renderer/utils.js`.
+- One renderer helper that emits the icon as a button with `data-gh-external-url="<url>"`.
+- One row of CSS: `.gh-ext-link { opacity: 0 }` then `.gh-item:hover .gh-ext-link, .gh-ci-item:hover .gh-ext-link, .gh-notif-item:hover .gh-ext-link, .gh-repo-header:hover .gh-ext-link { opacity: 1 }`.
+- Each delegated click handler intercepts in this order: (1) `[data-gh-external-url]` click → openExternal + stopPropagation; (2) `event.metaKey` on the row → openExternal + return; (3) fall through to the existing detail-open behaviour.
+- One new repo-header row inside `gh-inline-section`, above `#gh-content`, showing `owner/repo` + the icon. `ghState.cachedAuth.repo` already holds `{owner, name, url}`. `#gh-inline-section > .gh-subnav { display: none }` only hides immediate `.gh-subnav` children — the new header is unaffected.
+- Notifications need the only piece of non-trivial logic: the REST `/notifications` endpoint returns `subject.url` as an API URL (`api.github.com/repos/X/Y/issues/N`), not an html URL. Translate server-side in `main/github.js` and emit `htmlUrl` on each notification. Rows whose subject URL can't be translated (Releases, Discussions, null) simply don't get an icon.
+
+## Verified tool behavior
+
+### `gh:notifications` response shape
+
+GitHub REST `/repos/{owner}/{repo}/notifications` returns notifications with this subject shape (from the REST v3 docs, https://docs.github.com/en/rest/activity/notifications):
+```
+{
+  "subject": {
+    "title": "...",
+    "url": "https://api.github.com/repos/octocat/Hello-World/issues/123",
+    "latest_comment_url": "...",
+    "type": "Issue" | "PullRequest" | "Commit" | "Release" | "Discussion" | ...
+  }
+}
+```
+The notification itself has **no** top-level html_url field; the html URL must be derived from `subject.url` + `subject.type`. Patterns:
+- `api.github.com/repos/{X}/{Y}/issues/{N}` → `github.com/{X}/{Y}/issues/{N}`
+- `api.github.com/repos/{X}/{Y}/pulls/{N}` → `github.com/{X}/{Y}/pull/{N}` (singular!)
+- `api.github.com/repos/{X}/{Y}/commits/{SHA}` → `github.com/{X}/{Y}/commit/{SHA}` (singular!)
+- Releases (ID, not tag): not deterministically derivable → return null.
+- Discussions / null subject.url → return null.
+
+### Existing IPC
+
+`window.windowActions.openExternal(url)` is already exposed (preload.js:196 → main `window:open-external`). The handler validates the URL is `http:`/`https:`/`mailto:` before passing to `shell.openExternal`, so the renderer can pass any URL without additional sanitisation. Used by `renderer/terminals.js:66` (cmd-click in xterm) and `renderer/terminals.js:429` (web-links addon).
+
+### `url` fields present on existing IPC responses
+
+- `gh:pr-list` — `url` ✓ (gh-cli `--json url`)
+- `gh:pr-view` — `url` ✓
+- `gh:issue-list` — `url` ✓
+- `gh:issue-view` — `url` ✓
+- `gh:run-list` — `url` ✓ (added recently)
+- `gh:run-view` — `url` ✓
+- `gh:notifications` — needs html_url enrichment (see above)
+- `ghState.cachedAuth.repo` — `url` ✓ (set in `main/github.js:34` via `gh repo view --json owner,name,url,defaultBranchRef`)
+
+## Unknowns
+
+None blocking. Releases / Discussion notifications will skip the icon, which is acceptable degradation.
+
+## Files inventory
+
+- `renderer/utils.js` — SVG constants and small helpers.
+- `renderer/github-panel.js` — `refreshGitHub` (repo header), `refreshGitHubCI`, `refreshGitHubNotifs`.
+- `renderer/github-prs.js` — PR list rows.
+- `renderer/github-issues.js` — issue list rows.
+- `main/github.js` — notification htmlUrl enrichment.
+- `styles.css` — hover affordance.
+- `test/notifications-html-url.test.js` — new test for the URL helper.

--- a/specs/spec-20260520-open-github-items-in-browser/spec.md
+++ b/specs/spec-20260520-open-github-items-in-browser/spec.md
@@ -101,7 +101,9 @@ Target: ≤8 files changed, ≤400 lines added/removed, ≤20 tasks. Breach is a
 
 ## Course corrections
 
-_Nothing recorded yet._
+- 2026-05-20: Mis-targeted the first commit. Ran `cd /Users/derek/repos/braska && git commit` from the main checkout (which is on the `main` branch), instead of staying in the worktree at `/Users/derek/repos/braska.worktrees/gh-issue-66`. Recovery: in the worktree, `git reset --hard <my-commit-sha>` to advance `gh-issue-66`; in the main checkout, `git reset --hard origin/main` to rewind `main`. No remote impact (push had not yet happened). Lesson: never `cd /Users/derek/repos/braska` from inside a worktree; use absolute paths to the worktree, or stay in the worktree's cwd.
+- 2026-05-20: Size budget breach — 11 files / 495 lines vs `≤8 files / ≤400 lines`. Spec docs (research.md / spec.md / baseline-verify.md / verify-results.md) account for 4 of the 11 files; code + test files alone are 7. Lines are similarly inflated by spec content. Code is within budget; leaving the PR as one logical unit since splitting the spec from the code would lose the "commit code + spec together" guarantee.
+- 2026-05-20: Advisor post-review tidy — (a) `.gh-repo-header` had `border-bottom: 1px solid #1a1a1a`, which would stack with `.gh-subnav`'s own `border-bottom` to produce a 2px-thick separator. Removed. (b) Test `passes through enterprise GHE hosts` was overstating coverage — the regex matches only `api.<host>` shapes (api.github.com + GHE Cloud tenants), not GHE Server's `<host>/api/v3/...`. Renamed + added an inline comment so future readers don't mistake it for GHE Server support.
 
 ## Subagent notes
 

--- a/specs/spec-20260520-open-github-items-in-browser/spec.md
+++ b/specs/spec-20260520-open-github-items-in-browser/spec.md
@@ -1,0 +1,125 @@
+# Spec — Open GitHub items in browser from the GitHub panel (#66)
+
+Issue: https://github.com/derek-hobden/braska/issues/66 · branch: `gh-issue-66` · started: 2026-05-20T00:00:00Z
+
+**Status:** Ready for commit. 76/76 tests pass (8 new for the notification URL helper). UI verification is manual and pending — the renderer is ESM with browser-only globals (`window.windowActions`, `document.*`), and the existing `node --test` infra doesn't load a DOM.
+
+## Issue body
+
+> ## Problem
+>
+> When I click the GitHub icon on a project/repo and the GitHub panel opens on the right, there's no convenient way to jump to that resource on github.com in my browser.
+>
+> This applies to every item the panel surfaces:
+> - The repo itself (top-level header / title)
+> - PRs
+> - Issues
+> - CI runs / workflow runs
+> - Notifications
+>
+> ## Desired UX
+>
+> Some nice affordance — e.g. a small external-link icon on hover, a right-click "Open on GitHub" menu, or cmd-click on the row — that opens the corresponding github.com URL in the default browser.
+>
+> Should feel consistent across all five item types so it's discoverable once and works everywhere.
+
+## Chosen approach
+
+Add one consistent affordance applied to all five item types in the GitHub panel: a small external-link icon visible on row hover, plus cmd-click on the row, both of which call the existing `window.windowActions.openExternal(url)` IPC. A new repo-header row above `#gh-content` surfaces the repo as a clickable item with the same affordance. Notifications gain an `htmlUrl` field — derived server-side from `subject.url` and `subject.type` — because the REST `/notifications` endpoint returns API URLs, not html URLs.
+
+## Assumptions
+
+- ✓ **confident** — `ghState.cachedAuth.repo` carries `{owner, name, url}` and is populated before `refreshGitHub` reaches `gh-content` rendering.
+  - _Basis (file:line)_: `main/github.js:34` — `gh repo view --json owner,name,url,defaultBranchRef` runs in the `gh:auth-status` handler and the renderer caches the result at `renderer/github-panel.js:75`.
+
+- ✓ **confident** — `window.windowActions.openExternal(url)` opens an `http(s):` URL in the user's default browser via Electron `shell.openExternal`, after validating the protocol.
+  - _Basis (file:line)_: `preload.js:196` exposes the bridge; `main/browser-view.js:126-137` is the handler — explicit protocol whitelist.
+
+- ✓ **confident** — `#gh-inline-section > .gh-subnav { display: none }` only hides immediate `.gh-subnav` children, so a new `.gh-repo-header` sibling above `#gh-content` is unaffected.
+  - _Basis (file:line)_: `styles.css:1755` uses `>` direct-child combinator.
+
+- ✓ **confident** — The github.com URL for an issue/PR/commit notification can be derived from its `subject.url` + `subject.type`. Releases require the tag (only the ID is in `subject.url`), so releases skip the icon.
+  - _Basis (reproducer)_: see research.md → Verified tool behavior → GitHub REST `/notifications` shape. Mapping rules: issues→issues, pulls→pull, commits→commit. Pluralisation difference is intentional (github.com is singular).
+
+- ✓ **confident** — Existing delegated click handlers in `refreshGitHubPRs`, `refreshGitHubIssues`, `refreshGitHubCI`, `refreshGitHubNotifs` can be extended in-place. Each uses `ghResetListeners()` to scope listeners to a fresh `AbortController`.
+  - _Basis (file:line)_: `renderer/github-panel.js:23-25`, called before each `content.addEventListener('click', ...)`.
+
+## Definition of done
+
+- Hovering over a repo, PR row, issue row, CI run row, or notification row reveals a small `↗` icon. Clicking it opens the corresponding github.com URL in the default browser.
+- Cmd-clicking anywhere on those rows opens the github.com URL instead of opening the in-panel detail view.
+- Existing left-click behaviour (opening the detail view, switching filters, etc.) is unchanged.
+- For notifications referring to Releases/Discussions/unknown subject types, no icon is shown (better to omit than to synthesise a broken URL).
+- `node --test test/` is green; the new notification URL helper has unit-test coverage.
+
+## Up-front tests
+
+- `test/notifications-html-url.test.js::notificationSubjectToHtmlUrl handles issues/pulls/commits and returns null for releases/discussions/null`
+
+## Tasks
+
+Statuses: `- [ ]` pending, `- [x]` done. **▶ Active** marks the next pending task.
+
+- [x] Add `notificationSubjectToHtmlUrl(apiUrl, type)` to `main/github.js` (or a small adjacent file `main/github-notifications-url.js`), exported alongside `register`. Cover Issue, PullRequest, Commit, null/unknown.
+  - _Story: As the notifications panel, when I have a subject `{url, type}`, I can ask for the html URL or get `null` so the renderer knows whether to show the icon._
+  - _test: `test/notifications-html-url.test.js`_
+- [x] Enrich `gh:notifications` handler so each returned notification has `htmlUrl` (possibly null) at the top level.
+  - _Story: As the renderer, when I render a notification row, `n.htmlUrl` already tells me whether and where to link._
+- [x] Add `SVG_EXTERNAL_LINK` to `renderer/utils.js`, plus a small helper `ghExtLink(url)` that returns the HTML for the icon button (empty string when url is falsy).
+- [x] Update PR list rendering in `renderer/github-prs.js` to include `data-gh-row-url` on each `.gh-item` and the `ghExtLink(pr.url)` inside. Extend the delegated handler to (1) intercept `[data-gh-external-url]` clicks, (2) intercept `metaKey` row clicks, then (3) fall through to the existing detail-open.
+- [x] Same change in `renderer/github-issues.js` for the issue list.
+- [x] Same change in `renderer/github-panel.js::refreshGitHubCI` for the CI list (`run.url`).
+- [x] Same change in `renderer/github-panel.js::refreshGitHubNotifs` for the notifications list — skip the icon and skip cmd-click handling for rows where `n.htmlUrl` is null.
+- [x] Add a repo-header row in `renderer/github-panel.js::refreshGitHub` above `#gh-content`, showing `owner/repo` with the icon. Skip when `ghState.cachedAuth.repo` is missing.
+- [x] Add CSS in `styles.css`: `.gh-ext-link` button base style (transparent, small, currentColor SVG) hidden at opacity 0; visible on `.gh-item:hover`, `.gh-ci-item:hover`, `.gh-notif-item:hover`, `.gh-repo-header:hover`. Plus `.gh-repo-header` styling.
+
+## Verify
+
+```bash
+cd /Users/derek/repos/braska && node --test test/*.test.js test/*.test.mjs
+```
+
+## Size budget
+
+Target: ≤8 files changed, ≤400 lines added/removed, ≤20 tasks. Breach is a warning, not a block.
+
+## Decisions
+
+- 2026-05-20: Reused existing branch `gh-issue-66` and existing worktree `/Users/derek/repos/braska.worktrees/gh-issue-66` — both already match issue #66 per the skill's branch-already-encodes-the-issue rule.
+- 2026-05-20: Spec-location cached as `tracked:specs` (matches the repo's existing `specs/spec-*` convention).
+- 2026-05-20: Chose hover-visible icon + metaKey row-click over an always-visible icon and over a native context menu. Hover matches the issue text and keeps dense list rows uncluttered. Right-click context menu would need an Electron IPC + Menu.popup per row type and is out of scope.
+- 2026-05-20: Notification URL helper lives in `main/github.js` (server-side enrichment) rather than the renderer — keeps renderer code DOM-only and makes the only non-trivial mapping testable via `node --test`.
+- 2026-05-20: Skipping detail-view icons (PR detail, issue detail, CI run detail). The list-row affordance covers every item type once; doubling up on detail pages adds touchpoints without proportional UX value.
+- 2026-05-20: Releases / Discussions / null `subject.url` → emit `htmlUrl: null` and the renderer omits the icon. Better than synthesising a wrong URL.
+- 2026-05-20: Baseline: `npm test` / `node --test test/` fails on Node 25.8.1 with `Cannot find module '/.../test'`. Node 25 changed how `--test <dir>` resolves — the directory-walk mode is broken on the current local Node. Workaround for Verify: invoke with explicit globs `node --test test/*.test.js test/*.test.mjs`. The CI workflow (`claude.yml`) only runs on `@claude` mentions, not on push/PR, so this does not gate the PR. Filed as a follow-up: update `package.json` `test` script or document the Node-25 break.
+
+## Don'ts (rejected approaches and disproved assumptions)
+
+- ✗ Don't translate the notification API URL in the renderer. The renderer must not know about REST URL shapes; it would also make the mapping untestable through the existing `node --test` setup.
+- ✗ Don't add `--delete-branch` style "force every notification to have a URL" workaround. Releases need the tag, not the ID; synthesising a 404 link is worse than no link.
+- ✗ Don't add the icon to detail-view headers in this PR — explicit scope cap.
+
+## Course corrections
+
+_Nothing recorded yet._
+
+## Subagent notes
+
+_None._
+
+## Follow-ups (deferred work)
+
+- A native Electron right-click context menu ("Copy GitHub URL", "Open on GitHub") for power users.
+- Icon affordance on detail-view headers (PR detail, issue detail, CI run detail).
+
+## Open questions
+
+_None._
+
+## Baseline verify (pre-implementation)
+
+_Populated at end of Phase 3 by the verify script._
+
+## Verification results (post-implementation)
+
+_Populated in Phase 5._

--- a/specs/spec-20260520-open-github-items-in-browser/spec.md
+++ b/specs/spec-20260520-open-github-items-in-browser/spec.md
@@ -1,8 +1,8 @@
 # Spec — Open GitHub items in browser from the GitHub panel (#66)
 
-Issue: https://github.com/derek-hobden/braska/issues/66 · branch: `gh-issue-66` · started: 2026-05-20T00:00:00Z
+Issue: https://github.com/derek-hobden/braska/issues/66 · PR: https://github.com/derek-hobden/braska/pull/72 · branch: `gh-issue-66` · started: 2026-05-20T00:00:00Z
 
-**Status:** Ready for commit. 76/76 tests pass (8 new for the notification URL helper). UI verification is manual and pending — the renderer is ESM with browser-only globals (`window.windowActions`, `document.*`), and the existing `node --test` infra doesn't load a DOM.
+**Status:** Draft awaiting manual UI verification. 76/76 tests pass (8 new for the notification URL helper). No CI is configured for non-`@claude` events on this repo so CI cannot gate; the renderer is ESM with browser-only globals (`window.windowActions`, `document.*`) and `node --test` has no DOM, so the UI is not machine-verified in this PR.
 
 ## Issue body
 

--- a/specs/spec-20260520-open-github-items-in-browser/verify-results.md
+++ b/specs/spec-20260520-open-github-items-in-browser/verify-results.md
@@ -1,0 +1,47 @@
+# Verification results
+Captured: 2026-05-20T08:41:36Z
+Head commit: 06a379b1562caa88681564934ffe3346b82a7fcc
+
+## $ node --test test/*.test.js test/*.test.mjs
+exit: 0
+▶ ISSUE_BRANCH_RE
+  ✔ matches gh-issue-N (original UI-created format) (0.617959ms)
+  ✔ matches claude/issue-N (agent-created format) (0.121208ms)
+  ✔ matches bare issue-N (0.06525ms)
+  ✔ extracts the correct number (0.057125ms)
+  ✔ does not match main (0.052792ms)
+  ✔ does not match a plain feature branch (0.0495ms)
+✔ ISSUE_BRANCH_RE (1.755959ms)
+▶ computeJourneyCards
+  ✔ shows pull-remote card when pushBehind > 0 and NO dirty files (0.796417ms)
+  ✔ does NOT show pull-remote card when pushBehind > 0 AND dirty files exist (0.088042ms)
+  ✔ shows commit card when dirty files exist (0.069125ms)
+  ✔ shows only conflicts card when conflicted files exist (0.818916ms)
+  ✔ shows behind-main card when behind > 0 and clean (0.07675ms)
+  ✔ shows push card when pushAhead > 0 with upstream (0.065083ms)
+  ✔ shows share card for unpublished feature branch with commits (0.063416ms)
+  ✔ shows post-merge card when mergeInfo is provided (0.067625ms)
+  ✔ returns empty array when nothing is actionable (0.090416ms)
+  ✔ diverged state — shows sync card when pushAhead > 0 and pushBehind > 0 (clean) (0.126708ms)
+  ✔ diverged state — does NOT show separate pull-remote or share cards when diverged (0.069917ms)
+  ✔ diverged state — dirty files still show commit card (not sync card) (0.798125ms)
+✔ computeJourneyCards (4.103375ms)
+▶ notificationSubjectToHtmlUrl
+  ✔ maps Issue subject.url to github.com /issues/N (0.707417ms)
+  ✔ maps PullRequest subject.url to github.com /pull/N (pulls → pull) (0.140459ms)
+  ✔ maps Commit subject.url to github.com /commit/<sha> (commits → commit) (0.073875ms)
+  ✔ returns null for Release subject (only API ID is known, not the tag) (0.054292ms)
+  ✔ returns null for Discussion (no convertible subject URL pattern) (0.051541ms)
+  ✔ returns null when subject.url is null/undefined (0.053459ms)
+  ✔ returns null when subject.url is not an api.github.com URL we recognise (0.05125ms)
+  ✔ passes through enterprise GHE hosts (api.<host> → <host>) (0.049791ms)
+✔ notificationSubjectToHtmlUrl (2.005375ms)
+ℹ tests 76
+ℹ suites 12
+ℹ pass 76
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 249.835375
+

--- a/styles.css
+++ b/styles.css
@@ -3832,6 +3832,42 @@
     .gh-notif-title { flex: 1; color: #ccc; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .gh-notif-reason { color: #555; font-size: 0.68rem; flex-shrink: 0; }
     .gh-notif-time { color: #444; font-size: 0.68rem; flex-shrink: 0; }
+
+    /* Open-on-GitHub affordance. Hover-only icon button on rows that carry a github.com URL. */
+    .gh-repo-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px 4px;
+      font-size: 0.72rem;
+      color: #888;
+      font-family: Menlo, Monaco, "Courier New", monospace;
+      cursor: pointer;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    .gh-repo-header:hover { background: #1c1c1c; color: #ccc; }
+    .gh-repo-header-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .gh-ext-link {
+      flex-shrink: 0;
+      width: 18px;
+      height: 18px;
+      padding: 2px;
+      background: transparent;
+      border: none;
+      color: #888;
+      cursor: pointer;
+      opacity: 0;
+      transition: opacity 0.1s ease-in;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .gh-ext-link svg { width: 100%; height: 100%; }
+    .gh-ext-link:hover { color: #4a9eff; }
+    .gh-item:hover .gh-ext-link,
+    .gh-ci-item:hover .gh-ext-link,
+    .gh-notif-item:hover .gh-ext-link,
+    .gh-repo-header:hover .gh-ext-link { opacity: 1; }
     .gh-empty {
       color: #444;
       font-size: 0.8rem;

--- a/styles.css
+++ b/styles.css
@@ -3833,7 +3833,8 @@
     .gh-notif-reason { color: #555; font-size: 0.68rem; flex-shrink: 0; }
     .gh-notif-time { color: #444; font-size: 0.68rem; flex-shrink: 0; }
 
-    /* Open-on-GitHub affordance. Hover-only icon button on rows that carry a github.com URL. */
+    /* Open-on-GitHub affordance. Hover-only icon button on rows that carry a github.com URL.
+       No border-bottom: .gh-subnav (rendered directly below) already supplies a separator. */
     .gh-repo-header {
       display: flex;
       align-items: center;
@@ -3843,7 +3844,6 @@
       color: #888;
       font-family: Menlo, Monaco, "Courier New", monospace;
       cursor: pointer;
-      border-bottom: 1px solid #1a1a1a;
     }
     .gh-repo-header:hover { background: #1c1c1c; color: #ccc; }
     .gh-repo-header-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/styles.css
+++ b/styles.css
@@ -174,6 +174,7 @@
     }
     .wt-ci-glyph.pass { color: #3fb950; }
     .wt-ci-glyph.fail { color: #f85149; }
+    .wt-ci-glyph.conflict { color: #d18616; }
     .wt-ci-dot.pending {
       position: relative;
       display: inline-block;

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -4,17 +4,18 @@ const { mockExec, installMocks, loadModule, mockIpcMain } = require('./helpers')
 
 describe('prCheckStatus', async () => {
   const { prCheckStatus } = await import('../renderer/utils.js');
+  const pr = (rollup, extras = {}) => ({ statusCheckRollup: rollup, mergeable: 'UNKNOWN', isDraft: false, ...extras });
 
-  it('returns null for null rollup', () => {
+  it('returns null for null pr', () => {
     assert.equal(prCheckStatus(null), null);
   });
 
-  it('returns null for empty rollup', () => {
-    assert.equal(prCheckStatus([]), null);
+  it('returns null for empty rollup with unknown mergeability', () => {
+    assert.equal(prCheckStatus(pr([])), null);
   });
 
-  it('returns null for undefined rollup', () => {
-    assert.equal(prCheckStatus(undefined), null);
+  it('returns null for undefined rollup with unknown mergeability', () => {
+    assert.equal(prCheckStatus(pr(undefined)), null);
   });
 
   it('returns pass when all CheckRuns succeeded', () => {
@@ -22,7 +23,7 @@ describe('prCheckStatus', async () => {
       { __typename: 'CheckRun', conclusion: 'SUCCESS', status: 'COMPLETED' },
       { __typename: 'CheckRun', conclusion: 'NEUTRAL', status: 'COMPLETED' },
     ];
-    assert.equal(prCheckStatus(rollup), 'pass');
+    assert.equal(prCheckStatus(pr(rollup)), 'pass');
   });
 
   it('returns fail on FAILURE conclusion', () => {
@@ -30,21 +31,21 @@ describe('prCheckStatus', async () => {
       { __typename: 'CheckRun', conclusion: 'SUCCESS', status: 'COMPLETED' },
       { __typename: 'CheckRun', conclusion: 'FAILURE', status: 'COMPLETED' },
     ];
-    assert.equal(prCheckStatus(rollup), 'fail');
+    assert.equal(prCheckStatus(pr(rollup)), 'fail');
   });
 
   it('returns fail on ERROR conclusion', () => {
     const rollup = [
       { __typename: 'CheckRun', conclusion: 'ERROR', status: 'COMPLETED' },
     ];
-    assert.equal(prCheckStatus(rollup), 'fail');
+    assert.equal(prCheckStatus(pr(rollup)), 'fail');
   });
 
   it('returns fail on TIMED_OUT conclusion', () => {
     const rollup = [
       { __typename: 'CheckRun', conclusion: 'TIMED_OUT', status: 'COMPLETED' },
     ];
-    assert.equal(prCheckStatus(rollup), 'fail');
+    assert.equal(prCheckStatus(pr(rollup)), 'fail');
   });
 
   it('returns pending when a CheckRun has no conclusion (in progress)', () => {
@@ -52,42 +53,42 @@ describe('prCheckStatus', async () => {
       { __typename: 'CheckRun', conclusion: null, status: 'IN_PROGRESS' },
       { __typename: 'CheckRun', conclusion: 'SUCCESS', status: 'COMPLETED' },
     ];
-    assert.equal(prCheckStatus(rollup), 'pending');
+    assert.equal(prCheckStatus(pr(rollup)), 'pending');
   });
 
   it('returns pending when a CheckRun status is QUEUED', () => {
     const rollup = [
       { __typename: 'CheckRun', conclusion: null, status: 'QUEUED' },
     ];
-    assert.equal(prCheckStatus(rollup), 'pending');
+    assert.equal(prCheckStatus(pr(rollup)), 'pending');
   });
 
   it('returns pass for StatusContext with state SUCCESS (regression for ghChecksBadge bug)', () => {
     const rollup = [
       { __typename: 'StatusContext', state: 'SUCCESS' },
     ];
-    assert.equal(prCheckStatus(rollup), 'pass');
+    assert.equal(prCheckStatus(pr(rollup)), 'pass');
   });
 
   it('returns fail for StatusContext with state FAILURE', () => {
     const rollup = [
       { __typename: 'StatusContext', state: 'FAILURE' },
     ];
-    assert.equal(prCheckStatus(rollup), 'fail');
+    assert.equal(prCheckStatus(pr(rollup)), 'fail');
   });
 
   it('returns fail for StatusContext with state ERROR', () => {
     const rollup = [
       { __typename: 'StatusContext', state: 'ERROR' },
     ];
-    assert.equal(prCheckStatus(rollup), 'fail');
+    assert.equal(prCheckStatus(pr(rollup)), 'fail');
   });
 
   it('returns pending for StatusContext with state PENDING', () => {
     const rollup = [
       { __typename: 'StatusContext', state: 'PENDING' },
     ];
-    assert.equal(prCheckStatus(rollup), 'pending');
+    assert.equal(prCheckStatus(pr(rollup)), 'pending');
   });
 
   it('fail takes priority over pending', () => {
@@ -95,7 +96,7 @@ describe('prCheckStatus', async () => {
       { __typename: 'CheckRun', conclusion: null, status: 'IN_PROGRESS' },
       { __typename: 'CheckRun', conclusion: 'FAILURE', status: 'COMPLETED' },
     ];
-    assert.equal(prCheckStatus(rollup), 'fail');
+    assert.equal(prCheckStatus(pr(rollup)), 'fail');
   });
 
   it('mixed CheckRun and StatusContext — all passing', () => {
@@ -103,7 +104,28 @@ describe('prCheckStatus', async () => {
       { __typename: 'CheckRun', conclusion: 'SUCCESS', status: 'COMPLETED' },
       { __typename: 'StatusContext', state: 'SUCCESS' },
     ];
-    assert.equal(prCheckStatus(rollup), 'pass');
+    assert.equal(prCheckStatus(pr(rollup)), 'pass');
+  });
+
+  it('returns conflict when mergeable is CONFLICTING', () => {
+    assert.equal(prCheckStatus(pr([], { mergeable: 'CONFLICTING' })), 'conflict');
+  });
+
+  it('conflict takes priority over passing checks', () => {
+    const rollup = [{ __typename: 'CheckRun', conclusion: 'SUCCESS', status: 'COMPLETED' }];
+    assert.equal(prCheckStatus(pr(rollup, { mergeable: 'CONFLICTING' })), 'conflict');
+  });
+
+  it('returns pass when no checks but PR is mergeable and not draft', () => {
+    assert.equal(prCheckStatus(pr([], { mergeable: 'MERGEABLE' })), 'pass');
+  });
+
+  it('returns null when no checks but PR is draft', () => {
+    assert.equal(prCheckStatus(pr([], { mergeable: 'MERGEABLE', isDraft: true })), null);
+  });
+
+  it('returns null when no checks and mergeability is unknown', () => {
+    assert.equal(prCheckStatus(pr([], { mergeable: 'UNKNOWN' })), null);
   });
 });
 

--- a/test/notifications-html-url.test.js
+++ b/test/notifications-html-url.test.js
@@ -1,0 +1,69 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { notificationSubjectToHtmlUrl } = require('../main/github');
+
+describe('notificationSubjectToHtmlUrl', () => {
+  it('maps Issue subject.url to github.com /issues/N', () => {
+    const out = notificationSubjectToHtmlUrl(
+      'https://api.github.com/repos/octocat/Hello-World/issues/123',
+      'Issue',
+    );
+    assert.equal(out, 'https://github.com/octocat/Hello-World/issues/123');
+  });
+
+  it('maps PullRequest subject.url to github.com /pull/N (pulls → pull)', () => {
+    const out = notificationSubjectToHtmlUrl(
+      'https://api.github.com/repos/octocat/Hello-World/pulls/42',
+      'PullRequest',
+    );
+    assert.equal(out, 'https://github.com/octocat/Hello-World/pull/42');
+  });
+
+  it('maps Commit subject.url to github.com /commit/<sha> (commits → commit)', () => {
+    const out = notificationSubjectToHtmlUrl(
+      'https://api.github.com/repos/octocat/Hello-World/commits/abc123def',
+      'Commit',
+    );
+    assert.equal(out, 'https://github.com/octocat/Hello-World/commit/abc123def');
+  });
+
+  it('returns null for Release subject (only API ID is known, not the tag)', () => {
+    const out = notificationSubjectToHtmlUrl(
+      'https://api.github.com/repos/octocat/Hello-World/releases/9876',
+      'Release',
+    );
+    assert.equal(out, null);
+  });
+
+  it('returns null for Discussion (no convertible subject URL pattern)', () => {
+    const out = notificationSubjectToHtmlUrl(null, 'Discussion');
+    assert.equal(out, null);
+  });
+
+  it('returns null when subject.url is null/undefined', () => {
+    assert.equal(notificationSubjectToHtmlUrl(null, 'Issue'), null);
+    assert.equal(notificationSubjectToHtmlUrl(undefined, 'PullRequest'), null);
+  });
+
+  it('returns null when subject.url is not an api.github.com URL we recognise', () => {
+    assert.equal(
+      notificationSubjectToHtmlUrl('https://example.com/foo/bar', 'Issue'),
+      null,
+    );
+    assert.equal(
+      notificationSubjectToHtmlUrl(
+        'https://api.github.com/repos/octocat/Hello-World/something-unknown/1',
+        'Issue',
+      ),
+      null,
+    );
+  });
+
+  it('passes through enterprise GHE hosts (api.<host> → <host>)', () => {
+    const out = notificationSubjectToHtmlUrl(
+      'https://api.github.acme.corp/repos/team/proj/issues/7',
+      'Issue',
+    );
+    assert.equal(out, 'https://github.acme.corp/team/proj/issues/7');
+  });
+});

--- a/test/notifications-html-url.test.js
+++ b/test/notifications-html-url.test.js
@@ -59,7 +59,10 @@ describe('notificationSubjectToHtmlUrl', () => {
     );
   });
 
-  it('passes through enterprise GHE hosts (api.<host> → <host>)', () => {
+  // Only api.<host>-style URLs match (api.github.com and GHE Cloud tenants like
+  // api.<tenant>.ghe.com). GHE Server (uses <host>/api/v3/repos/...) is not covered;
+  // those rows skip the icon via the null fallback.
+  it('passes through api.<host>-style tenants by stripping the api. prefix', () => {
     const out = notificationSubjectToHtmlUrl(
       'https://api.github.acme.corp/repos/team/proj/issues/7',
       'Issue',


### PR DESCRIPTION
## Summary

Adds a consistent affordance across all five GitHub-panel item types (repo, PRs, issues, CI runs, notifications): a small external-link icon visible on row hover, plus cmd-click on the row, both of which open the corresponding github.com URL in the default browser via the existing `window.windowActions.openExternal` IPC. Closes #66.

## What changed

- New repo-header row above `#gh-content` in `refreshGitHub`, showing `owner/repo` with the same affordance. Pulled from `ghState.cachedAuth.repo` which already carries the html URL.
- PR / issue / CI-run / notification list rows now carry `data-gh-row-url` and embed an `↗` icon button (`data-gh-external-url`). One shared `handleGhExternalClick` helper in `renderer/github-panel.js` intercepts both affordances in order; each section's existing delegated click handler delegates to it first, then falls through to its existing detail-open / filter behaviour.
- Hover-only CSS — `.gh-ext-link` is opacity 0 by default and goes to 1 when its row is hovered.
- Notifications: `gh:notifications` now enriches each row with `htmlUrl`, derived server-side in `main/github.js::notificationSubjectToHtmlUrl` from `subject.url` + `subject.type` (the REST `/notifications` endpoint returns API URLs, not html URLs). Issue → `/issues/N`, PullRequest → `/pull/N`, Commit → `/commit/<sha>`. Releases / Discussions / unknown patterns return `null`, so those rows skip the icon rather than synthesise a broken URL.

## Verification

- Tests: 76 pass, 0 fail (`node --test test/*.test.js test/*.test.mjs`). 8 new tests for the URL helper cover Issue / PullRequest / Commit / Release / Discussion / null / non-github / GHE-host paths.
- UI: **not** machine-verified in this PR — the renderer is browser-only (`window.windowActions`, `document.*`) and the repo's `node --test` infra has no DOM. Manual check recommended before merging: hover each of repo header / PR row / issue row / CI run row / notification row → `↗` icon appears; click icon → opens in default browser; cmd-click row → opens in default browser; plain click row → still opens the detail view as before.

## Notes

- Baseline: `npm test` (and `node --test test/`) fail on Node 25.x with `Cannot find module '.../test'` — a Node-25 change to how `--test <directory>` resolves arguments. The Verify block uses the working glob form. Not gating this PR; filed as a follow-up to update `package.json` `test` to a glob.
- Spec, research, baseline + final verify logs: `specs/spec-20260520-open-github-items-in-browser/`.

Drafted via /fix-issue