### PR TITLE
[routine] Sidebar worktree badge shows stale modified-files count after commit until manual refresh

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -208,6 +208,8 @@ window.filetree.onChange((filename) => {
       if (entry && !entry.classList.contains('is-git')) loadProjects();
       // Always refresh git panel on .git changes, even when viewing todo/github
       refreshChanges(tabState.activeWorkDir);
+      // Keep sidebar badge in sync after commits/amends/rebases
+      refreshWorktreeMetrics();
       return;
     }
     const activePanel = document.querySelector('.filetree-tab.active')?.dataset.panel;
@@ -269,7 +271,7 @@ initWorktreeModals({ loadProjects, openWorkDir, closeTab, tabsForWorkDir, startT
 bindSettingsDeps({ openWorkDir, setBreadcrumb });
 initSettings();
 initTabs({ showTabTypePicker, updateFileTreeHighlights, showTodoClosePrompt, refreshTodos, updateTodoFocus, refreshRightPanel });
-initTerminals({ refreshRightPanel });
+initTerminals({ refreshRightPanel, refreshWorktreeMetrics });
 initNotifications({ openWorkDir, switchTab, exitSettings });
 initFileExplorer({ openFileEditor, openDiffTab, refreshChanges, startTask, startBrowser, switchTab, refreshTodos, refreshGitHub });
 initGitChanges({ refreshFileTree, startTask, loadProjects, switchTab, addTabToOrder, renderTabBar, tabsForWorkDir });

--- a/renderer/terminals.js
+++ b/renderer/terminals.js
@@ -19,6 +19,7 @@ const xtermModulesPromise = Promise.all([
 
 // ── Cross-module deps (set via initTerminals) ──────────────────
 let refreshRightPanel = null;
+let refreshWorktreeMetrics = null;
 
 // ── Terminal tab creation ──────────────────────────────────────
 
@@ -132,6 +133,9 @@ export async function startTask(agentName, workDir, options = {}) {
     if (agentName === 'committer') onCommitterExit(workDir);
     if (agentName === 'github-specialist') onGithubSpecialistExit(workDir);
     if (workDir === tabState.activeWorkDir) refreshRightPanel(workDir);
+    // Refresh sidebar badge for all worktrees on exit — covers background-worktree commits
+    // where the fs.watch (active-workdir only) never fires for the committing worktree.
+    refreshWorktreeMetrics();
   });
   term.onData(data => window.pty.write(id, data));
   term.onResize(({ cols, rows }) => window.pty.resize(id, cols, rows));
@@ -494,6 +498,7 @@ export async function openFileEditor(relPath, fileName) {
 
 // ── Initialization ─────────────────────────────────────────────
 
-export function initTerminals({ refreshRightPanel: _refreshRightPanel }) {
+export function initTerminals({ refreshRightPanel: _refreshRightPanel, refreshWorktreeMetrics: _refreshWorktreeMetrics }) {
   refreshRightPanel = _refreshRightPanel;
+  refreshWorktreeMetrics = _refreshWorktreeMetrics;
 }

--- a/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/baseline-verify.md
+++ b/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/baseline-verify.md
@@ -1,0 +1,18 @@
+# Baseline Verify — pre-implementation
+
+Command: `node --test test/*.test.js test/*.test.mjs`
+Exit code: 0
+
+```
+1..20
+# tests 101
+# suites 14
+# pass 101
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 440.226405
+```
+
+Note: `npm test` fails with `Error: Cannot find module '/home/user/braska/test'` because `node --test` treats a directory path as a single file. This is a pre-existing condition; all tests pass when invoked with the explicit glob pattern above.

--- a/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/research.md
+++ b/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/research.md
@@ -1,0 +1,133 @@
+# Research — Sidebar worktree badge shows stale modified-files count after commit until manual refresh (#76)
+
+## Problem summary
+
+The sidebar worktree badge (the "14M" modified-files count pill) is rendered by `refreshWorktreeMetrics()` in `renderer/sidebar.js`. After a commit that clears all changes, the badge stays stale because the `filetree.onChange` handler in `app.js` calls `refreshChanges()` but not `refreshWorktreeMetrics()` — and the PTY `onExit` handler in `terminals.js` calls `refreshRightPanel()` (itself not touching the badge) gated only on the active worktree. Background-worktree commits are never refreshed through any path.
+
+## Approaches considered
+
+**Approach A — Add `refreshWorktreeMetrics()` to the `filetree.onChange` isGitChange branch (app.js)**
+One-sentence: When the fs.watch fires for any `.git/`-prefixed filename (which happens on every commit), also call `refreshWorktreeMetrics()`.
+- Pros: Covers all commit sources (manual modal, agent PTY, raw terminal git commands). Low-risk; the function is already called in `app.js`. Consistent with how every other git mutation (stage/unstage/discard/push/pull) works.
+- Cons: Fires on every `.git/` event, not just commits — e.g. also on staging, which already calls `refreshWorktreeMetrics()` via the action path (double refresh). The 300 ms debounce window collapses all events in a burst, so in practice it fires once.
+- Precedent: The same handler already calls `refreshChanges()` in this branch; `refreshWorktreeMetrics()` is the missing sibling call.
+
+**Approach B — Add `refreshWorktreeMetrics()` to the PTY `onExit` handler in terminals.js**
+One-sentence: When any agent PTY exits, call `refreshWorktreeMetrics()` unconditionally (not gated on `workDir === activeWorkDir`).
+- Pros: Covers background worktree commits; the agent may have committed while the user was viewing a different worktree and the fs.watch only covers the active worktree.
+- Cons: Fires on every agent exit, including exits that have nothing to do with git (e.g. a browser research session).
+- Precedent: The `onExit` handler already calls `refreshRightPanel(workDir)` (gated on activeWorkDir), so adding a metrics call alongside it is a natural extension.
+
+**Approach C — Combined: both A and B**
+One-sentence: Apply both fixes so every commit path — fs.watch event, interactive PTY agent exit, background PTY agent exit — triggers a sidebar refresh.
+- Pros: Exhaustive coverage; handles the active-worktree case fast (via fs.watch debounce) and the background-worktree case on exit. No single change is enough on its own.
+- Cons: For an active-worktree commit by an agent, `refreshWorktreeMetrics()` will fire twice (once from the fs.watch, once from `onExit`). The function is already idempotent and called multiple times in other flows; the duplicate is harmless.
+- Precedent: The existing `onPushSuccess` in `git-changes.js` already calls both `refreshChanges()` and `refreshWorktreeMetrics()` in the same codepath, accepting the double-call as the correct pattern.
+
+**Approach D — Add a periodic metrics poll (e.g. every 30 s)**
+One-sentence: Schedule a `setInterval` to call `refreshWorktreeMetrics()` periodically, independent of events.
+- Pros: Catches any missed event (including external `git commit` in a terminal outside Braska).
+- Cons: Architecturally inconsistent — every other metric refresh is event-driven; a poll adds latency and CPU budget concern.
+- Precedent: None in the codebase for file-status metrics.
+
+## Recommended approach
+
+**Approach C (both A and B).**
+
+Fix A handles the common case instantly (300 ms after any `.git/` write, regardless of whether the commit came from the modal, a PTY agent, or a raw terminal). Fix B additionally handles the gap where a committer agent exits after the user has switched to a different worktree tab — in that case the fs.watch is pointed at the new workDir, so fix A never fires for the original worktree. Both changes are single-line additions consistent with every other git mutation in the codebase.
+
+## Verified tool behavior
+
+**Claim 1:** `fs.watch(worktreeDir, { recursive: true })` fires events with `filename` values that start with `.git/` during a `git commit`.
+
+- **Reproducer:** 
+  ```sh
+  mkdir -p /tmp/spec-stale-badge-smoke/testrepo
+  cd /tmp/spec-stale-badge-smoke/testrepo
+  git init && git config user.email t@t.com && git config user.name T
+  echo hello > file.txt && git add file.txt && git commit -m init
+  echo changed > file.txt && git add file.txt
+  node watch_test.js
+  ```
+- **Observed output:**
+  ```
+  type=rename filename=".git/objects/01"
+  type=change filename=".git/index"
+  type=change filename=".git/COMMIT_EDITMSG"
+  type=change filename=".git/logs/HEAD"
+  type=change filename=".git/refs/heads/master"
+  Total .git events: 14
+  Has .git or .git/ prefixed filename: true
+  ```
+- **Verdict:** Claim holds.
+- **Implication:** The `isGitChange` guard in `app.js` correctly identifies every commit event. Adding `refreshWorktreeMetrics()` in that branch will fire for every commit (debounced to one call per 300 ms burst).
+
+---
+
+**Claim 2:** The `app.js` `filetree.onChange` handler's `isGitChange` branch does NOT call `refreshWorktreeMetrics()`, it returns early after calling `refreshChanges()`.
+
+- **Reproducer:** Read `/home/user/braska/renderer/app.js` lines 200–216.
+- **Observed output:**
+  ```js
+  if (isGitChange) {
+    const entry = document.querySelector(...);
+    if (entry && !entry.classList.contains('is-git')) loadProjects();
+    refreshChanges(tabState.activeWorkDir);
+    return;   // <-- early return, no refreshWorktreeMetrics
+  }
+  ```
+- **Verdict:** Claim holds.
+- **Implication:** This is the primary missing call site for fix A.
+
+---
+
+**Claim 3:** The `terminals.js` `pty.onExit` handler calls `refreshRightPanel(workDir)` gated on `workDir === activeWorkDir`, but never calls `refreshWorktreeMetrics()`.
+
+- **Reproducer:** Read `/home/user/braska/renderer/terminals.js` lines 128–135.
+- **Observed output:**
+  ```js
+  window.pty.onExit(id, code => {
+    ...
+    if (agentName === 'committer') onCommitterExit(workDir);
+    if (agentName === 'github-specialist') onGithubSpecialistExit(workDir);
+    if (workDir === tabState.activeWorkDir) refreshRightPanel(workDir);
+    // no refreshWorktreeMetrics call
+  });
+  ```
+- **Verdict:** Claim holds.
+- **Implication:** This is the missing call site for fix B; the `workDir === activeWorkDir` guard confirms why background-worktree commits are never covered.
+
+---
+
+**Claim 4:** `refreshRightPanel()` does not call `refreshWorktreeMetrics()`.
+
+- **Reproducer:** Read `/home/user/braska/renderer/app.js` lines 85–94.
+- **Observed output:**
+  ```js
+  export function refreshRightPanel(workDir) {
+    const filetreePanel = document.getElementById('filetree-panel');
+    if (filetreePanel.classList.contains('hidden') || !workDir) return;
+    const activePanel = document.querySelector('.filetree-tab.active')?.dataset.panel;
+    if (activePanel === 'changes') refreshChanges(workDir);
+    else if (activePanel === 'todo') refreshTodos(workDir);
+    else if (activePanel === 'github') refreshGitHub(workDir);
+    else refreshFileTree(workDir);
+  }
+  ```
+- **Verdict:** Claim holds.
+- **Implication:** Confirms that even when `refreshRightPanel` is called on agent exit, it never updates the sidebar badge.
+
+## Unknowns
+
+- Whether non-main worktrees (those where `.git` is a file, not a directory) have the same fs.watch coverage for refs changes. The `main/files.js` watcher sets up a separate `gitWatcher` for the real git dir in those cases, emitting `.git/index` as the synthetic filename; whether it reliably catches refs changes from the real git dir for linked worktrees was not fully verified.
+- Performance: `refreshWorktreeMetrics()` runs `git status --porcelain` plus multiple `git rev-list` calls per worktree. Repositories with many worktrees will take proportionally longer; no performance budget was measured.
+
+## Files inventory
+
+- `renderer/sidebar.js` — Defines `refreshWorktreeMetrics()` (calls `window.worktree.metrics`) and renders the `.wt-metrics` badge HTML.
+- `renderer/app.js` — Entry point; contains the `filetree.onChange` handler where `refreshWorktreeMetrics()` is missing from the `isGitChange` branch. Also defines `refreshRightPanel()`.
+- `renderer/terminals.js` — PTY onExit handler; calls `refreshRightPanel` for active worktree but not `refreshWorktreeMetrics`. Fix B goes here.
+- `renderer/git-changes-modals.js` — Working reference: the manual commit modal `submitBtn` handler calls both `_refreshChanges(workDir)` and `_refreshWorktreeMetrics()` on success — this is the pattern the fix should replicate.
+- `main/git-read.js` — `git:worktree-metrics` IPC handler; runs `git status --porcelain` per worktree to compute the counts.
+- `main/files.js` — Implements `filetree:watch` IPC handler using `fs.watch({ recursive: true })`; emits `filetree:changed` with the filename that triggered the event.
+- `preload.js` — Context-bridge wiring; `window.worktree.metrics` maps to `git:worktree-metrics`.

--- a/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/spec.md
+++ b/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/spec.md
@@ -2,7 +2,7 @@
 
 Issue: [#76](https://github.com/derek-hobden/braska/issues/76) · PR: [#79](https://github.com/derek-hobden/braska/pull/79) · branch: `claude/issue-76` · started: 2026-05-21T00:00:00Z
 
-**Status:** Implementation complete; verifying.
+**Status:** Complete. All verify commands passed.
 
 ## Issue body
 

--- a/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/spec.md
+++ b/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/spec.md
@@ -1,0 +1,116 @@
+# Spec — Sidebar worktree badge shows stale modified-files count after commit until manual refresh (#76)
+
+Issue: [#76](https://github.com/derek-hobden/braska/issues/76) · PR: [#79](https://github.com/derek-hobden/braska/pull/79) · branch: `claude/issue-76` · started: 2026-05-21T00:00:00Z
+
+**Status:** Spec drafted; implementation not started.
+
+## Issue body
+
+> ## Repro
+> 1. On a worktree with many modified files (e.g. 14), commit them all so the working tree is clean (no staged or unstaged changes).
+> 2. Look at the worktree entry in the left sidebar.
+>
+> ## Actual
+> The pill next to the worktree name still shows `14M`, as if 14 files were still modified.
+>
+> ## Expected
+> The badge should clear (or update to the new count) as soon as the commit completes, matching the now-clean working tree.
+>
+> ## Notes
+> - A manual refresh updates the UI correctly, so the underlying status read is fine — the auto-refresh trigger after a commit is what's missing/stale.
+> - Likely related to the sidebar worktree status pill not being invalidated on commit events from the git changes panel / terminal-driven commits.
+
+## Chosen approach
+
+Two one-line additions, one in each of the two paths that miss the badge refresh:
+
+**Fix A** — In `renderer/app.js`, add `refreshWorktreeMetrics()` to the `isGitChange` branch of the `filetree.onChange` handler (before the early `return`). Every commit writes to `.git/refs/heads/…`, which fires the fs.watch, which hits this branch. The badge is currently not updated here; `refreshChanges` is called instead. Adding `refreshWorktreeMetrics()` as a sibling call closes the bug for every commit source that touches the active worktree: manual modal, agent PTY, raw terminal.
+
+**Fix B** — In `renderer/terminals.js`, expose `refreshWorktreeMetrics` as an injected dependency via `initTerminals` (alongside the existing `refreshRightPanel`), then call it unconditionally in the `pty.onExit` handler. The existing `refreshRightPanel` call is gated on `workDir === tabState.activeWorkDir`, so background-worktree commits are never covered. `refreshWorktreeMetrics` runs across all worktrees anyway, so no guard is needed.
+
+Both changes are consistent with the established pattern in `git-changes-modals.js` where every successful commit calls both `_refreshChanges` and `_refreshWorktreeMetrics`.
+
+## Assumptions
+
+- ✓ **confident** — `filetree.onChange` fires during a commit because `git commit` writes to `.git/refs/heads/…`, whose filename is matched by `filename.startsWith('.git/')`.
+  - _Basis (reproducer)_: see research.md → Verified tool behavior → "Claim 1". fs.watch emitted 14 events with `.git/`-prefixed filenames during a `git commit` run.
+
+- ✓ **confident** — The `isGitChange` branch in `app.js` does not call `refreshWorktreeMetrics()`.
+  - _Basis (file:line)_: `renderer/app.js:205-211` — the branch calls `refreshChanges(tabState.activeWorkDir)` then `return`; no `refreshWorktreeMetrics` call is present.
+
+- ✓ **confident** — The `pty.onExit` handler in `terminals.js` does not call `refreshWorktreeMetrics()`, and the existing `refreshRightPanel` call is guarded by `workDir === tabState.activeWorkDir`.
+  - _Basis (file:line)_: `renderer/terminals.js:128-135` — only `refreshRightPanel(workDir)` is called, gated on the active worktree check.
+
+- ✓ **confident** — `refreshWorktreeMetrics` is exported from `renderer/sidebar.js` and is already imported in `renderer/app.js`.
+  - _Basis (file:line)_: `renderer/app.js:5` — `import { ..., refreshWorktreeMetrics, ... } from './sidebar.js'`.
+
+- ✓ **confident** — `initTerminals` in `terminals.js` receives its cross-module deps as a plain object; adding a new key is non-breaking.
+  - _Basis (file:line)_: `renderer/terminals.js:497-499` — `export function initTerminals({ refreshRightPanel: _refreshRightPanel }) { refreshRightPanel = _refreshRightPanel; }`.
+
+- ✓ **confident** — A duplicate call to `refreshWorktreeMetrics()` (once from the fs.watch event, once from PTY onExit) is harmless; the function is idempotent.
+  - _Basis (file:line)_: `renderer/git-changes-modals.js:95,102,119` — the commit modal already calls `_refreshWorktreeMetrics()` multiple times in its success path without guard.
+
+## Definition of done
+
+- After committing all changed files in a worktree, the sidebar badge for that worktree clears within ~1 s without any manual refresh.
+- After an agent PTY (e.g. `committer`) exits on a background worktree (not the one currently viewed), its sidebar badge clears when next seen.
+- Running `node --test test/*.test.js test/*.test.mjs` exits 0 with all tests passing.
+
+## Up-front tests
+
+The renderer has no test infrastructure (all tests in `test/` target the main process via Node.js `require`). The changes are two wiring lines in renderer event handlers; writing a meaningful unit test would require setting up a full DOM mock environment that doesn't exist in this project. The TDD carve-out applies: tests would be performative given the missing infrastructure.
+
+No new test files are added.
+
+## Tasks
+
+Statuses: `- [ ]` pending, `- [x]` done, `- [ ] ~~text~~ — deferred: <reason>` deferred.
+
+- [ ] **▶ Active** — Fix A: add `refreshWorktreeMetrics()` to the `isGitChange` branch in `renderer/app.js`
+  - _Story: As a developer, when I commit all staged changes so the working tree is clean, then the sidebar worktree badge clears within ~1 s without manual refresh._
+  - _test: no test (renderer; see Up-front tests rationale)_
+- [ ] Fix B: pass and call `refreshWorktreeMetrics` in `renderer/terminals.js` PTY `onExit` handler
+  - _Story: As a developer, when a committer agent on a background worktree exits, the badge for that worktree shows the updated count when I next look at it._
+  - _test: no test (renderer; see Up-front tests rationale)_
+
+## Verify
+
+```bash
+node --test test/*.test.js test/*.test.mjs
+```
+
+## Decisions
+
+_Appended chronologically as implementation reveals choices._
+
+## Don'ts (rejected approaches and disproved assumptions)
+
+_Nothing disproved yet._
+
+## Course corrections
+
+_None._
+
+## Subagent notes
+
+Research subagent confirmed via live reproducers:
+- `fs.watch` fires `.git/`-prefixed filenames on commit (14 events observed in `/tmp/spec-stale-badge-smoke/testrepo`).
+- `app.js` `isGitChange` branch has no `refreshWorktreeMetrics` call.
+- `terminals.js` `onExit` handler has no `refreshWorktreeMetrics` call.
+- `refreshRightPanel` itself never calls `refreshWorktreeMetrics`.
+
+## Follow-ups (deferred work)
+
+_None._
+
+## Open questions
+
+_None._
+
+## Baseline verify (pre-implementation)
+
+_Populated at end of Phase 2._
+
+## Verification results (post-implementation)
+
+_Populated in Phase 4._

--- a/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/spec.md
+++ b/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/spec.md
@@ -2,7 +2,7 @@
 
 Issue: [#76](https://github.com/derek-hobden/braska/issues/76) · PR: [#79](https://github.com/derek-hobden/braska/pull/79) · branch: `claude/issue-76` · started: 2026-05-21T00:00:00Z
 
-**Status:** Spec drafted; implementation not started.
+**Status:** Implementation complete; verifying.
 
 ## Issue body
 
@@ -66,10 +66,10 @@ No new test files are added.
 
 Statuses: `- [ ]` pending, `- [x]` done, `- [ ] ~~text~~ — deferred: <reason>` deferred.
 
-- [ ] **▶ Active** — Fix A: add `refreshWorktreeMetrics()` to the `isGitChange` branch in `renderer/app.js`
+- [x] Fix A: add `refreshWorktreeMetrics()` to the `isGitChange` branch in `renderer/app.js`
   - _Story: As a developer, when I commit all staged changes so the working tree is clean, then the sidebar worktree badge clears within ~1 s without manual refresh._
   - _test: no test (renderer; see Up-front tests rationale)_
-- [ ] Fix B: pass and call `refreshWorktreeMetrics` in `renderer/terminals.js` PTY `onExit` handler
+- [x] Fix B: pass and call `refreshWorktreeMetrics` in `renderer/terminals.js` PTY `onExit` handler
   - _Story: As a developer, when a committer agent on a background worktree exits, the badge for that worktree shows the updated count when I next look at it._
   - _test: no test (renderer; see Up-front tests rationale)_
 
@@ -81,7 +81,7 @@ node --test test/*.test.js test/*.test.mjs
 
 ## Decisions
 
-_Appended chronologically as implementation reveals choices._
+2026-05-21: TDD carve-out applied for both fixes. All tests in `test/` target the main process via `node:test` + CJS `require`; the renderer is DOM/ESM with no test infrastructure. Writing meaningful unit tests for these two wiring lines would require setting up a full DOM mock environment that doesn't exist in this project. The TDD carve-out threshold ("test would be performative") is met. Both changes add `refreshWorktreeMetrics()` as a sibling call alongside already-tested call sites.
 
 ## Don'ts (rejected approaches and disproved assumptions)
 

--- a/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/verify-results.md
+++ b/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/verify-results.md
@@ -1,0 +1,23 @@
+# Verify Results — post-implementation
+
+Command: `node --test test/*.test.js test/*.test.mjs`
+Exit code: 0
+
+```
+1..20
+# tests 101
+# suites 14
+# pass 101
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 429.712301
+```
+
+## Comparison with baseline
+
+Baseline: 101 pass, 0 fail
+Results:  101 pass, 0 fail
+
+No regressions. No new failures.


### PR DESCRIPTION
Closes #76

Status: **spec drafted; implementing**

Spec:
https://github.com/derek-hobden/braska/blob/claude/issue-76/specs/spec-20260521-sidebar-worktree-badge-stale-after-commit/spec.md

Routine session: https://claude.ai/code/session_01B7skcd1wKv1kCGKEwoCBwF

Watch the commit log for task progress. Reply on this PR to answer questions or unblock.